### PR TITLE
Serialize scan partitions in proto

### DIFF
--- a/integrations/datafusion/gen/proto/indexlake_datafusion.proto
+++ b/integrations/datafusion/gen/proto/indexlake_datafusion.proto
@@ -16,12 +16,29 @@ message IndexLakeScanExecNode {
   string namespace_name = 1;
   string table_name = 2;
   uint32 partition_count = 3;
-  DataFiles data_files = 4;
+  repeated TableScanPartition partitions = 4;
   Projection projection = 5;
   repeated datafusion.LogicalExprNode filters = 6;
   uint32 batch_size = 7;
   optional uint32 limit = 8;
   datafusion_common.Schema schema = 9;
+}
+
+message TableScanPartition {
+  oneof partition_type {
+    TableScanPartitionAuto auto = 1;
+    TableScanPartitionProvided provided = 2;
+  }
+}
+
+message TableScanPartitionAuto {
+  uint32 partition_idx = 1;
+  uint32 partition_count = 2;
+}
+
+message TableScanPartitionProvided {
+  bool contains_inline_rows = 1;
+  repeated DataFile data_file_records = 2;
 }
 
 message IndexLakeInsertExecNode {
@@ -33,10 +50,6 @@ message IndexLakeInsertExecNode {
 
 message Projection {
   repeated uint32 projection = 1;
-}
-
-message DataFiles {
-  repeated DataFile files = 1;
 }
 
 message DataFile {

--- a/integrations/datafusion/src/protobuf.rs
+++ b/integrations/datafusion/src/protobuf.rs
@@ -26,8 +26,8 @@ pub struct IndexLakeScanExecNode {
     pub table_name: ::prost::alloc::string::String,
     #[prost(uint32, tag = "3")]
     pub partition_count: u32,
-    #[prost(message, optional, tag = "4")]
-    pub data_files: ::core::option::Option<DataFiles>,
+    #[prost(message, repeated, tag = "4")]
+    pub partitions: ::prost::alloc::vec::Vec<TableScanPartition>,
     #[prost(message, optional, tag = "5")]
     pub projection: ::core::option::Option<Projection>,
     #[prost(message, repeated, tag = "6")]
@@ -38,6 +38,35 @@ pub struct IndexLakeScanExecNode {
     pub limit: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "9")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TableScanPartition {
+    #[prost(oneof = "table_scan_partition::PartitionType", tags = "1, 2")]
+    pub partition_type: ::core::option::Option<table_scan_partition::PartitionType>,
+}
+/// Nested message and enum types in `TableScanPartition`.
+pub mod table_scan_partition {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum PartitionType {
+        #[prost(message, tag = "1")]
+        Auto(super::TableScanPartitionAuto),
+        #[prost(message, tag = "2")]
+        Provided(super::TableScanPartitionProvided),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TableScanPartitionAuto {
+    #[prost(uint32, tag = "1")]
+    pub partition_idx: u32,
+    #[prost(uint32, tag = "2")]
+    pub partition_count: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TableScanPartitionProvided {
+    #[prost(bool, tag = "1")]
+    pub contains_inline_rows: bool,
+    #[prost(message, repeated, tag = "2")]
+    pub data_file_records: ::prost::alloc::vec::Vec<DataFile>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IndexLakeInsertExecNode {
@@ -54,11 +83,6 @@ pub struct IndexLakeInsertExecNode {
 pub struct Projection {
     #[prost(uint32, repeated, tag = "1")]
     pub projection: ::prost::alloc::vec::Vec<u32>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DataFiles {
-    #[prost(message, repeated, tag = "1")]
-    pub files: ::prost::alloc::vec::Vec<DataFile>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataFile {

--- a/integrations/datafusion/src/table.rs
+++ b/integrations/datafusion/src/table.rs
@@ -18,6 +18,7 @@ use indexlake::utils::schema_without_row_id;
 use log::warn;
 use tokio::sync::Mutex;
 
+use crate::scan::build_scan_partitions;
 use crate::{
     IndexLakeInsertExec, IndexLakeScanExec, datafusion_expr_to_indexlake_expr,
     indexlake_expr_to_datafusion_expr,
@@ -135,11 +136,11 @@ impl TableProvider for IndexLakeTable {
         )
         .with_table(self.table.clone());
 
+        let scan_partitions = Arc::new(build_scan_partitions(self.num_scan_partitions, data_files));
         let exec = IndexLakeScanExec::try_new(
             lazy_table,
             self.table.output_schema.clone(),
-            self.num_scan_partitions,
-            data_files,
+            scan_partitions,
             il_projection,
             filters.to_vec(),
             self.batch_size,


### PR DESCRIPTION
## Summary
- Serialize TableScanPartition vec in IndexLakeScanExec proto
- Update codec encode/decode and protobuf types to use partitions
- Remove obsolete data-files serialization helper

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo build --all-targets --all-features