### PR TITLE
Add async table statistics builder

### DIFF
--- a/integrations/datafusion/src/table.rs
+++ b/integrations/datafusion/src/table.rs
@@ -56,14 +56,7 @@ impl IndexLakeTable {
         })
     }
 
-    pub async fn with_table_statistics(
-        mut self,
-        enable_table_statistics: bool,
-    ) -> Result<Self, DataFusionError> {
-        if !enable_table_statistics {
-            return Ok(self);
-        }
-
+    pub async fn with_table_statistics(mut self) -> Result<Self, DataFusionError> {
         let counts = self
             .table
             .count(&[TableScanPartition::single_partition()])


### PR DESCRIPTION
## Summary
- Keep IndexLakeTable::try_new signature unchanged
- Add async with_table_statistics to fetch row count when enabled
- Reuse cached row count in statistics()

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo build --all-targets --all-features