### PR TITLE
Cache partition row counts for scan statistics

### DIFF
--- a/integrations/datafusion/gen/proto/indexlake_datafusion.proto
+++ b/integrations/datafusion/gen/proto/indexlake_datafusion.proto
@@ -22,6 +22,7 @@ message IndexLakeScanExecNode {
   uint32 batch_size = 7;
   optional uint32 limit = 8;
   datafusion_common.Schema schema = 9;
+  repeated uint64 partition_row_counts = 10;
 }
 
 message TableScanPartition {

--- a/integrations/datafusion/src/protobuf.rs
+++ b/integrations/datafusion/src/protobuf.rs
@@ -38,6 +38,8 @@ pub struct IndexLakeScanExecNode {
     pub limit: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "9")]
     pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
+    #[prost(uint64, repeated, tag = "10")]
+    pub partition_row_counts: ::prost::alloc::vec::Vec<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TableScanPartition {


### PR DESCRIPTION
## Summary
- Pass per-partition row counts into IndexLakeScanExec at construction
- Use cached row counts for partition statistics instead of runtime queries
- Serialize partition row counts in scan exec proto

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo build --all-targets --all-features