### PR TITLE
Benchmarks: use benchmark: prefix across all bins

### DIFF
--- a/benchmarks/src/bin/indexlake.rs
+++ b/benchmarks/src/bin/indexlake.rs
@@ -5,6 +5,7 @@ use futures::StreamExt;
 use indexlake::expr::{col, lit};
 use indexlake::table::{TableCreation, TableInsertion, TableScan, TableScanPartition, TableUpdate};
 use indexlake::{Client, ILError};
+use indexlake_benchmarks::benchprintln;
 use indexlake_benchmarks::data::{arrow_table_schema, new_record_batch};
 use indexlake_integration_tests::{catalog_postgres, init_env_logger, storage_s3};
 
@@ -56,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let insert_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake: inserted {} rows, {} tasks, batch size: {}, in {}ms",
         total_rows,
         num_tasks,
@@ -96,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(count, total_rows);
 
     let scan_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake: scanned {} rows by {} tasks in {}ms",
         count,
         num_tasks,
@@ -110,13 +111,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let update_count = table.update(update).await?;
     let update_cost_time = start_time.elapsed().as_millis();
-    println!("IndexLake: updated {update_count} rows in {update_cost_time}ms",);
+    benchprintln!("IndexLake: updated {update_count} rows in {update_cost_time}ms");
 
     let start_time = Instant::now();
     let condition = col("id").eq(lit(100i32));
     let delete_count = table.delete(condition).await?;
     let delete_cost_time = start_time.elapsed().as_millis();
-    println!("IndexLake: deleted {delete_count} rows in {delete_cost_time}ms",);
+    benchprintln!("IndexLake: deleted {delete_count} rows in {delete_cost_time}ms");
 
     Ok(())
 }

--- a/benchmarks/src/bin/indexlake_bm25.rs
+++ b/benchmarks/src/bin/indexlake_bm25.rs
@@ -8,6 +8,7 @@ use indexlake::index::IndexKind;
 use indexlake::storage::DataFileFormat;
 use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableInsertion, TableSearch};
 use indexlake::{Client, ILError};
+use indexlake_benchmarks::benchprintln;
 use indexlake_benchmarks::data::{arrow_bm25_table_schema, new_bm25_record_batch};
 use indexlake_index_bm25::{BM25IndexKind, BM25IndexParams, BM25SearchQuery};
 use indexlake_integration_tests::{catalog_postgres, init_env_logger, storage_s3};
@@ -80,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let insert_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake BM25: inserted {} rows, {} tasks, batch size: {}, format: {}, in {}ms",
         total_rows,
         num_tasks,
@@ -108,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let search_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake BM25: searched {} rows in {}ms",
         limit,
         search_cost_time.as_millis()

--- a/benchmarks/src/bin/indexlake_btree.rs
+++ b/benchmarks/src/bin/indexlake_btree.rs
@@ -11,19 +11,13 @@ use indexlake::index::IndexKind;
 use indexlake::storage::DataFileFormat;
 use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan};
 use indexlake::{Client, ILError};
+use indexlake_benchmarks::benchprintln;
 use indexlake_benchmarks::data::{
     arrow_btree_integer_table_schema, arrow_btree_string_table_schema,
     new_btree_integer_record_batch, new_btree_string_record_batch,
 };
 use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use indexlake_integration_tests::{catalog_postgres, init_env_logger, storage_s3};
-
-macro_rules! benchprintln {
-    ($($arg:tt)*) => {{
-        print!("benchmark: ");
-        println!($($arg)*);
-    }};
-}
 
 #[derive(Clone)]
 enum DataType {

--- a/benchmarks/src/bin/indexlake_hnsw.rs
+++ b/benchmarks/src/bin/indexlake_hnsw.rs
@@ -7,6 +7,7 @@ use indexlake::index::IndexKind;
 use indexlake::storage::DataFileFormat;
 use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableInsertion, TableSearch};
 use indexlake::{Client, ILError};
+use indexlake_benchmarks::benchprintln;
 use indexlake_benchmarks::data::{arrow_hnsw_table_schema, new_hnsw_record_batch};
 use indexlake_index_hnsw::{HnswIndexKind, HnswIndexParams, HnswSearchQuery};
 use indexlake_integration_tests::{catalog_postgres, init_env_logger, storage_s3};
@@ -81,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let insert_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake Hnsw: inserted {} rows, {} tasks, batch size: {}, format: {}, in {}ms",
         total_rows,
         num_tasks,
@@ -110,7 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(search_count, limit);
 
     let search_cost_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "IndexLake Hnsw: searched {} rows in {}ms",
         search_count,
         search_cost_time.as_millis()

--- a/benchmarks/src/bin/indexlake_rstar.rs
+++ b/benchmarks/src/bin/indexlake_rstar.rs
@@ -11,6 +11,7 @@ use indexlake::expr::{col, func, lit};
 use indexlake::index::IndexKind;
 use indexlake::storage::DataFileFormat;
 use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableScan};
+use indexlake_benchmarks::benchprintln;
 use indexlake_benchmarks::data::{arrow_rstar_table_schema, new_rstar_record_batch};
 use indexlake_index_rstar::{RStarIndexKind, RStarIndexParams, WkbDialect};
 use indexlake_integration_tests::{catalog_postgres, init_env_logger, storage_s3};
@@ -23,7 +24,7 @@ async fn benchmark_rstar(
     client: &Client,
     total_rows: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("--- R*-tree benchmark: {} rows ---", total_rows);
+    benchprintln!("--- R*-tree benchmark: {} rows ---", total_rows);
 
     let namespace_name = format!("rstar_benchmark_{}", uuid::Uuid::new_v4());
     client.create_namespace(&namespace_name, true).await?;
@@ -77,7 +78,7 @@ async fn benchmark_rstar(
     }
 
     let insert_time = start_time.elapsed();
-    println!(
+    benchprintln!(
         "insert: {} rows, {} tasks, batch size: {}, in {}ms",
         total_inserted,
         NUM_TASKS,
@@ -99,7 +100,7 @@ async fn benchmark_rstar(
     let index_start = Instant::now();
     table.create_index(index_creation).await?;
     let index_time = index_start.elapsed();
-    println!("index build: {}ms", index_time.as_millis());
+    benchprintln!("index build: {}ms", index_time.as_millis());
 
     let table = client.load_table(&namespace_name, &table_name).await?;
 
@@ -127,9 +128,11 @@ async fn benchmark_rstar(
     }
 
     let avg_query_ms = total_query_time.as_millis() / QUERY_COUNT as u128;
-    println!(
-        "query: {} queries, avg {}ms, total {} results\n",
-        QUERY_COUNT, avg_query_ms, total_results,
+    benchprintln!(
+        "query: {} queries, avg {}ms, total {} results",
+        QUERY_COUNT,
+        avg_query_ms,
+        total_results,
     );
 
     Ok(())
@@ -145,13 +148,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = Client::new(catalog, storage);
     client.register_index_kind(Arc::new(RStarIndexKind));
 
-    println!("=== IndexLake R*-tree benchmark suite ===\n");
+    benchprintln!("=== IndexLake R*-tree benchmark suite ===");
 
     for total_rows in [100_000, 1_000_000] {
         benchmark_rstar(&client, total_rows).await?;
     }
 
-    println!("=== benchmark complete ===");
+    benchprintln!("=== benchmark complete ===");
 
     Ok(())
 }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,1 +1,8 @@
 pub mod data;
+
+#[macro_export]
+macro_rules! benchprintln {
+    ($($arg:tt)*) => {{
+        println!("benchmark: {}", format_args!($($arg)*));
+    }};
+}


### PR DESCRIPTION
- Add a shared benchprintln! macro in the benchmarks crate that prefixes output with enchmark:\n- Update all benchmark binaries to use benchprintln! for key summary logs\n\nThis keeps the /bench workflow filtering behavior consistent if we ever run other benchmark bins.