### PR TITLE
Add index result columns for table scan and search

### DIFF
--- a/benchmarks/src/bin/indexlake_bm25.rs
+++ b/benchmarks/src/bin/indexlake_bm25.rs
@@ -100,6 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             limit: Some(limit),
         }),
         projection: None,
+        index_columns: vec![],
     };
     let mut stream = table.search(table_search).await?;
     let mut batches = vec![];

--- a/benchmarks/src/bin/indexlake_hnsw.rs
+++ b/benchmarks/src/bin/indexlake_hnsw.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             limit,
         }),
         projection: None,
+        index_columns: vec![],
     };
     let mut stream = table.search(table_search).await?;
     let mut search_count = 0;

--- a/docs/index-search-dynamic-columns.md
+++ b/docs/index-search-dynamic-columns.md
@@ -1,0 +1,560 @@
+# Index 动态列技术方案（Table Scan + Table Search）
+
+## 1. 背景
+
+`indexlake` 当前已经支持 index 参与 `table.search()` 排序，以及参与 `table.scan()` 过滤，但 index 产生的附加信息还不能作为结果集列返回。
+
+典型例子：
+
+- BM25 在搜索时已经能计算每条命中的 `score`
+- `table/search.rs` 已经会使用 `score` 做全局排序
+- 结果集最终只返回表字段，不返回 `score`
+
+同时，`table.scan()` 也已经存在索引过滤路径：
+
+- `table/scan.rs` 会把部分 filter 分配给 index
+- index 返回命中的 `row_id`
+- 表层再回表取出真正的数据行
+
+但 scan 路径同样没有“索引给结果集动态加列”的能力。
+
+本方案目标是统一 `TableScan` 和 `TableSearch` 两条链路，让 index 都可以按需给结果集添加动态列。BM25 的 `score` 只是第一批能力，不应作为特例硬编码在表层。
+
+## 2. 现状
+
+### 2.1 `table.search()` 现状
+
+[indexlake/src/table/search.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/search.rs) 当前流程：
+
+1. 根据 `SearchQuery.index_kind()` 选出目标 index
+2. 分别搜索 inline rows 和 data files
+3. 合并 `SearchIndexEntries`
+4. 回表读取基础列
+5. 按 `score` 排序
+6. 返回 `RecordBatch`
+
+当前索引搜索结果定义位于 [indexlake/src/index/mod.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/index/mod.rs)：
+
+```rust
+pub struct SearchIndexEntries {
+    pub row_id_scores: Vec<RowIdScore>,
+    pub score_higher_is_better: bool,
+}
+```
+
+这只能表达：
+
+- 命中了哪些行
+- 这些行的排序分值
+
+不能表达：
+
+- 需要返回哪些索引附加列
+- 附加列的数据类型
+- 附加列的别名
+
+### 2.2 `table.scan()` 现状
+
+[indexlake/src/table/scan.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/scan.rs) 当前流程分两类：
+
+- 无索引过滤：走普通表扫描
+- 有索引过滤：先由 index 过滤出 `row_id`，再回表读取匹配行
+
+当前索引过滤结果定义同样位于 [indexlake/src/index/mod.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/index/mod.rs)：
+
+```rust
+pub struct FilterIndexEntries {
+    pub row_ids: Vec<Uuid>,
+}
+```
+
+这同样无法表达动态列。
+
+另外，当前 `process_index_scan()` 直接拼接 inline/data-file stream，没有复用 `TablePartitionScanner` 的全局 `offset/limit` 逻辑。这意味着如果要在 index scan 路径增加动态列，顺带需要把结果整流逻辑一起补齐，否则行为不一致。
+
+### 2.3 Schema 侧已有基础
+
+[indexlake/src/utils.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/utils.rs) 中的 `correct_batch_schema()` 会把内部 field id 转回业务列名，但对普通字段名原样透传。
+
+因此，只要结果 batch 里追加的动态列名不是内部 field id，就不会在 schema 更正阶段被破坏。
+
+## 3. 目标与非目标
+
+### 3.1 目标
+
+1. `TableScan` 和 `TableSearch` 都支持 index 动态添加结果列
+2. 动态列必须显式请求，不默认返回
+3. 动态列用 Arrow 列返回，不走逐行对象拼装
+4. 表层不为 BM25/HNSW/BTree/RStar 写硬编码分支
+5. 不请求动态列时，现有行为保持不变
+
+### 3.2 非目标
+
+1. 本期不要求 DataFusion SQL 立刻暴露动态列
+2. 本期不支持动态列参与 `update/delete`
+3. 本期不设计“任意 index 在没有参与 scan/search 的情况下仍可独立产出全表列”
+4. 本期不做多 index 联合 search
+
+## 4. 设计原则
+
+1. 按需返回：调用方显式请求，index 才计算和返回
+2. index 自治：列名语义、类型、生成逻辑由 index 自己定义
+3. 表层通用：`table/scan.rs` 和 `table/search.rs` 只做调度、校验、拼装
+4. 列式优先：动态列保持 Arrow 原生列式表示
+5. 向后兼容：默认请求为空时，输出 schema 与现在一致
+
+## 5. 对外 API 设计
+
+### 5.1 统一的动态列请求结构
+
+新增统一请求结构：
+
+```rust
+pub struct IndexColumnRequest {
+    pub index_name: Option<String>,
+    pub name: String,
+    pub alias: Option<String>,
+}
+```
+
+字段含义：
+
+- `index_name`：动态列来自哪个 index
+- `name`：index 内部定义的逻辑列名，例如 `score`、`distance`
+- `alias`：结果集中的输出列名；为空时默认使用 `name`
+
+### 5.2 挂到 `TableSearch`
+
+```rust
+pub struct TableSearch {
+    pub query: Arc<dyn SearchQuery>,
+    pub projection: Option<Vec<usize>>,
+    pub index_columns: Vec<IndexColumnRequest>,
+}
+```
+
+校验规则：
+
+- `search` 本身只会命中一个目标 index
+- 如果 `index_name` 为空，默认绑定到这个目标 index
+- 如果 `index_name` 不为空，必须等于目标 index 名称，否则报错
+
+### 5.3 挂到 `TableScan`
+
+```rust
+pub struct TableScan {
+    pub projection: Option<Vec<usize>>,
+    pub filters: Vec<Expr>,
+    pub batch_size: usize,
+    pub partition: TableScanPartition,
+    pub offset: usize,
+    pub limit: Option<usize>,
+    pub index_columns: Vec<IndexColumnRequest>,
+}
+```
+
+校验规则：
+
+- `scan` 允许多个 index 同时参与过滤
+- `index_columns` 中的每一项必须能解析到某个实际参与本次 scan 的 index
+- 当 `index_name` 为空且本次 scan 参与过滤的 index 不唯一时，报错
+- 当请求的列来自未参与本次 scan 的 index 时，报错
+
+这样做的原因很直接：scan 场景下 index 来源可能不唯一，必须在入口消除歧义。
+
+## 6. Index 层扩展
+
+### 6.1 结果列结构
+
+新增 index 输出列结构：
+
+```rust
+pub struct IndexResultColumn {
+    pub field: FieldRef,
+    pub values: ArrayRef,
+}
+```
+
+约束：
+
+- `values.len()` 必须与当前结果集中行数一致
+- `field.name()` 为最终输出列名，已经处理 alias
+- `field.data_type()` 由 index 自己定义
+
+### 6.2 统一的结果列请求
+
+表层会把全局的 `IndexColumnRequest` 解析成“发给单个 index 的请求”：
+
+```rust
+pub struct RequestedIndexColumn {
+    pub name: String,
+    pub output_name: String,
+}
+
+pub struct IndexResultOptions {
+    pub columns: Vec<RequestedIndexColumn>,
+}
+```
+
+这样 `Index` trait 不需要理解跨 index 的全局请求，只需要处理“当前这个 index 要返回哪些列”。
+
+### 6.3 扩展 `Index` trait
+
+```rust
+#[async_trait::async_trait]
+pub trait Index {
+    async fn search(
+        &self,
+        query: &dyn SearchQuery,
+        options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries>;
+
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries>;
+}
+```
+
+### 6.4 扩展返回结构
+
+```rust
+pub struct SearchIndexEntries {
+    pub row_id_scores: Vec<RowIdScore>,
+    pub score_higher_is_better: bool,
+    pub dynamic_columns: Vec<IndexResultColumn>,
+}
+
+pub struct FilterIndexEntries {
+    pub row_ids: Vec<Uuid>,
+    pub dynamic_columns: Vec<IndexResultColumn>,
+}
+```
+
+说明：
+
+- `search` 场景仍保留 `row_id_scores` 作为排序依据
+- `filter` 场景没有统一排序语义，因此只返回 `row_ids`
+- 两者都允许返回动态列
+
+## 7. `TableSearch` 执行方案
+
+### 7.1 入口解析
+
+在 [indexlake/src/table/search.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/search.rs) 中：
+
+1. 先解析目标 search index
+2. 校验 `index_columns`
+3. 生成该 index 的 `IndexResultOptions`
+
+### 7.2 索引搜索阶段
+
+`search_inline_rows()` 和 `search_index_file()` 调用 `Index::search(query, options)`。
+
+index 返回：
+
+- `row_id_scores`
+- `dynamic_columns`
+
+对于 BM25：
+
+- 若未请求 `score`，`dynamic_columns` 为空
+- 若请求 `score`，返回 `Float64Array`
+
+### 7.3 合并阶段
+
+当前 `merge_search_index_entries()` 只合并 `row_id_scores`。改造后需同时合并动态列：
+
+1. 校验 inline 和各 data-file 返回的动态列集合一致
+2. 按现有逻辑合并 `row_id_scores`
+3. 对每个动态列按同一顺序拼接 array
+4. 生成一次全局排序索引
+5. 对基础表 batch 和所有动态列统一执行 `take`
+6. 如果存在 `limit`，同样只截一次
+
+关键约束：排序索引只能生成一次，否则动态列和基础表行容易错位。
+
+### 7.4 结果列顺序
+
+`search` 最终结果列顺序：
+
+1. `_row_id`
+2. `projection` 选出的基础表列
+3. `index_columns` 请求的动态列，按请求顺序追加
+
+## 8. `TableScan` 执行方案
+
+### 8.1 入口解析
+
+在 [indexlake/src/table/scan.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/scan.rs) 中：
+
+1. 先做现有的 filter 拆分
+2. 计算 `index_filter_assignment`
+3. 校验 `index_columns` 是否都能绑定到实际参与过滤的 index
+4. 为每个参与 scan 的 index 构造各自的 `IndexResultOptions`
+
+### 8.2 index filter 返回动态列
+
+`index_scan_inline_rows()` 和 `filter_index_files_row_ids()` 当前只消费 `row_ids`。改造后：
+
+- `Index::filter(filters, options)` 返回 `FilterIndexEntries`
+- 其中 `dynamic_columns` 与 `row_ids` 一一对齐
+
+示意：
+
+```rust
+pub struct FilterIndexEntries {
+    pub row_ids: Vec<Uuid>,
+    pub dynamic_columns: Vec<IndexResultColumn>,
+}
+```
+
+### 8.3 多 index 交集与动态列合并
+
+scan 场景比 search 复杂，因为可能有多个 index 同时参与过滤。
+
+建议合并规则：
+
+1. 每个 index 只返回自己负责的动态列
+2. 先按现有逻辑对各 index 的 `row_ids` 求交集
+3. 每个 index 的动态列仍保留“按本 index 的 row_ids 对齐”的原始形态
+4. 表层把它们转换成按 `row_id` 查值的内部结构
+5. 回表读取基础数据时，根据 `_row_id` 为每个 batch 补动态列
+
+内部建议引入仅表层可见的辅助结构：
+
+```rust
+struct RowMappedDynamicColumn {
+    field: FieldRef,
+    row_ids: Vec<Uuid>,
+    values: ArrayRef,
+}
+```
+
+或者进一步转成：
+
+```rust
+struct DynamicColumnLookup {
+    field: FieldRef,
+    row_id_to_pos: HashMap<Uuid, usize>,
+    values: ArrayRef,
+}
+```
+
+这样在 batch 级别追加列时，可以按 `_row_id` 逐批 gather，而不需要一次性 materialize 整个 scan 结果。
+
+### 8.4 流式追加动态列
+
+scan 的关键要求是保留 streaming。
+
+建议做法：
+
+1. index 先产出候选 `row_id` 和动态列 lookup
+2. 回表阶段仍按现在的 inline/data-file 分批读取基础行
+3. 每个输出 batch 取出 `_row_id`
+4. 对每个动态列按 `_row_id` 顺序 gather 出一个新 array
+5. 把新 array 追加到当前 batch 后输出
+
+这样可以保持：
+
+- 不需要把 scan 结果全部读入内存
+- 动态列和基础行天然同批次对齐
+
+### 8.5 `offset/limit` 的处理
+
+当前 index scan 路径没有复用 `TablePartitionScanner` 的窗口裁剪逻辑。扩展动态列时应一并修正。
+
+建议方案：
+
+1. 把 `offset/limit` 逻辑从 `TablePartitionScanner` 中抽成通用的 `LimitOffsetStream`
+2. 普通 table scan 和 index scan 都在“基础列 + 动态列已经拼好之后”走同一层窗口裁剪
+
+原因：
+
+- 如果先裁剪基础 batch，再补动态列，会增加错位风险
+- 统一在最终 batch 层裁剪，语义最稳定
+
+## 9. Schema 与校验规则
+
+### 9.1 输出 schema
+
+`TableScan::output_schema()` 和 `TableSearch` 的最终输出 schema 都需要扩展：
+
+1. 先生成基础表 schema
+2. 再按请求顺序追加动态列 field
+
+### 9.2 列名冲突
+
+以下情况直接报错：
+
+- 动态列输出名与基础表列重名
+- 两个动态列输出名相同
+- 同一 index 返回的实际 field 名与请求解析结果不一致
+
+不建议自动覆盖或自动重命名，否则 schema 不可预测。
+
+### 9.3 空结果
+
+即使结果集为空，只要请求了动态列，也必须保留这些字段。
+
+这样调用方才能稳定依赖 schema。
+
+### 9.4 不支持的动态列
+
+如果 index 不支持某个列名，应返回显式错误，例如：
+
+```text
+Unsupported result column `score` for index `btree_idx`
+```
+
+不应静默忽略。
+
+## 10. 不同 index 的首期语义
+
+### 10.1 BM25
+
+- `search` 支持 `score: Float64`
+- `scan` 暂时没有 filter 语义，因此当前没有可用动态列
+- 如果未来 BM25 支持 `match_bm25(...)` 形式的 filter，则可直接复用 `filter + dynamic_columns` 机制
+
+### 10.2 HNSW
+
+- `search` 可自然支持 `distance` 或 `score`
+- 因其当前只支持 search，不支持 filter，所以 scan 场景暂无动态列
+
+### 10.3 BTree / RStar
+
+- 当前主要用于 `scan` 过滤
+- 首期可以先不实现具体动态列
+- 但框架层必须允许它们未来返回例如 `matched_key`、`distance_to_boundary`、`spatial_relation` 等附加信息
+
+结论是：框架层现在就统一支持 `scan + search` 两条路径，具体 index 先按能力逐个接入。
+
+## 11. 对 DataFusion 的影响
+
+当前 DataFusion 集成的 schema 来自固定的 `table.output_schema`，位于 [integrations/datafusion/src/table.rs](/C:/Users/lewis/workspace/indexlake/integrations/datafusion/src/table.rs)。
+
+因此本期结论仍然是：
+
+- Rust API 的 `TableScan` / `TableSearch` 先支持动态列
+- DataFusion SQL 支持另开议题
+
+否则 `TableProvider::schema()` 无法静态声明动态列。
+
+## 12. 实现拆分建议
+
+### 12.1 第一步：核心结构
+
+改动文件：
+
+- [indexlake/src/index/mod.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/index/mod.rs)
+
+内容：
+
+- 增加 `IndexColumnRequest`
+- 增加 `RequestedIndexColumn`
+- 增加 `IndexResultOptions`
+- 扩展 `SearchIndexEntries`
+- 扩展 `FilterIndexEntries`
+- 修改 `Index::search()` / `Index::filter()` 签名
+
+### 12.2 第二步：`TableSearch`
+
+改动文件：
+
+- [indexlake/src/table/mod.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/mod.rs)
+- [indexlake/src/table/search.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/search.rs)
+
+内容：
+
+- `TableSearch` 增加 `index_columns`
+- 入口校验和请求解析
+- 搜索结果动态列合并
+- 排序后追加动态列
+
+### 12.3 第三步：`TableScan`
+
+改动文件：
+
+- [indexlake/src/table/scan.rs](/C:/Users/lewis/workspace/indexlake/indexlake/src/table/scan.rs)
+
+内容：
+
+- `TableScan` 增加 `index_columns`
+- index filter 路径返回动态列
+- 引入 batch 级动态列追加
+- 抽出统一的 `offset/limit` 裁剪逻辑
+
+### 12.4 第四步：index 逐个接入
+
+改动文件：
+
+- [indexes/bm25/src/index.rs](/C:/Users/lewis/workspace/indexlake/indexes/bm25/src/index.rs)
+- [indexes/hnsw/src/index.rs](/C:/Users/lewis/workspace/indexlake/indexes/hnsw/src/index.rs)
+- [indexes/btree/src/index.rs](/C:/Users/lewis/workspace/indexlake/indexes/btree/src/index.rs)
+- [indexes/rstar/src/index.rs](/C:/Users/lewis/workspace/indexlake/indexes/rstar/src/index.rs)
+
+内容：
+
+- BM25 先支持 `search.score`
+- 其他 index 先把接口接上，动态列可先返回空
+
+### 12.5 第五步：测试
+
+优先增加：
+
+1. `search` 不请求动态列时行为不变
+2. BM25 `search` 请求 `score` 时结果多一列
+3. `scan` 请求动态列但 index 未参与时报错
+4. `scan` 多 index 参与时列解析无歧义
+5. `scan` 动态列在多批次输出下不乱序
+6. `offset/limit` 在 index scan 路径与普通 scan 路径行为一致
+7. 空结果仍保留动态列 schema
+
+## 13. 风险与规避
+
+### 13.1 动态列和基础行错位
+
+规避：
+
+- `search` 只生成一次排序索引
+- `scan` 统一按 `_row_id` 做 batch 内 gather
+
+### 13.2 多 index 请求歧义
+
+规避：
+
+- scan 入口要求列请求能唯一解析到实际参与的 index
+
+### 13.3 空结果 schema 不稳定
+
+规避：
+
+- 动态列 field 在空 batch 也必须保留
+
+### 13.4 `offset/limit` 行为分叉
+
+规避：
+
+- 把窗口裁剪抽成 scan 路径共用组件
+
+## 14. 结论
+
+该方案把“index 产生的附加信息”统一升级为结果集动态列，并同时覆盖：
+
+- `TableSearch`：典型场景是 BM25/HNSW 返回 `score` / `distance`
+- `TableScan`：典型场景是过滤型 index 在回表结果上追加 index 计算列
+
+实现上最关键的点有三个：
+
+1. `TableScan` 和 `TableSearch` 共用 `IndexColumnRequest`
+2. `Index::search()` 和 `Index::filter()` 都能返回 `dynamic_columns`
+3. scan 路径按 `_row_id` 流式补列，search 路径按统一排序索引补列
+
+建议实现顺序：
+
+1. 先落核心抽象
+2. 再改 `TableSearch`
+3. 再改 `TableScan` 并顺手修正 index scan 的 `offset/limit`
+4. 最后让 BM25 先接入 `score`

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -1,9 +1,13 @@
 use std::any::Any;
+use std::sync::Arc;
 
+use arrow::array::Float64Array;
+use arrow::datatypes::Field;
 use bm25::Embedder;
 use indexlake::expr::Expr;
 use indexlake::index::{
-    FilterIndexEntries, Index, IndexDefinitionRef, RowIdScore, SearchIndexEntries, SearchQuery,
+    FilterIndexEntries, Index, IndexDefinitionRef, IndexResultColumn, IndexResultOptions,
+    RowIdScore, SearchIndexEntries, SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 
@@ -38,7 +42,11 @@ pub struct BM25Index {
 
 #[async_trait::async_trait]
 impl Index for BM25Index {
-    async fn search(&self, query: &dyn SearchQuery) -> ILResult<SearchIndexEntries> {
+    async fn search(
+        &self,
+        query: &dyn SearchQuery,
+        options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries> {
         let query = query
             .as_any()
             .downcast_ref::<BM25SearchQuery>()
@@ -57,13 +65,43 @@ impl Index for BM25Index {
             })
             .collect();
 
+        let mut dynamic_columns = Vec::new();
+        for column in &options.columns {
+            match column.name.as_str() {
+                "score" => dynamic_columns.push(IndexResultColumn {
+                    field: Arc::new(Field::new(
+                        &column.output_name,
+                        arrow::datatypes::DataType::Float64,
+                        false,
+                    )),
+                    values: Arc::new(Float64Array::from(
+                        row_id_scores
+                            .iter()
+                            .map(|row| row.score)
+                            .collect::<Vec<_>>(),
+                    )),
+                }),
+                _ => {
+                    return Err(ILError::invalid_input(format!(
+                        "Unsupported result column `{}` for index kind `bm25`",
+                        column.name
+                    )));
+                }
+            }
+        }
+
         Ok(SearchIndexEntries {
             row_id_scores,
             score_higher_is_better: true,
+            dynamic_columns,
         })
     }
 
-    async fn filter(&self, _filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        _filters: &[Expr],
+        _options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries> {
         Err(ILError::not_supported("BM25 index does not support filter"))
     }
 }

--- a/indexes/bm25/src/kind.rs
+++ b/indexes/bm25/src/kind.rs
@@ -1,11 +1,11 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Field, FieldRef};
 use indexlake::expr::Expr;
 use indexlake::index::{
     FilterSupport, IndexBuilder, IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams,
-    SearchQuery,
+    RequestedIndexColumn, SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 use serde::{Deserialize, Serialize};
@@ -56,6 +56,27 @@ impl IndexKind for BM25IndexKind {
         } else {
             Ok(false)
         }
+    }
+
+    fn output_fields(
+        &self,
+        _index_def: &IndexDefinition,
+        columns: &[RequestedIndexColumn],
+    ) -> ILResult<Vec<FieldRef>> {
+        columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "score" => Ok(Arc::new(Field::new(
+                    &column.output_name,
+                    DataType::Float64,
+                    false,
+                ))),
+                _ => Err(ILError::invalid_input(format!(
+                    "Unsupported result column `{}` for index kind `bm25`",
+                    column.name
+                ))),
+            })
+            .collect()
     }
 
     fn supports_filter(&self, _: &IndexDefinition, _: &Expr) -> ILResult<FilterSupport> {

--- a/indexes/btree/src/builder.rs
+++ b/indexes/btree/src/builder.rs
@@ -115,7 +115,8 @@ impl IndexBuilder for BTreeIndexBuilder {
     }
 
     fn build(&mut self) -> ILResult<Box<dyn Index>> {
-        let mut index = BTreeIndex::new();
+        let key_field = self.index_schema.fields[1].clone();
+        let mut index = BTreeIndex::new(key_field);
 
         for batch in self.index_batches.iter() {
             let row_id_array = batch.column(0).as_fixed_size_binary();

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -2,10 +2,16 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::sync::Arc;
 
+use arrow::array::{ArrayRef, new_null_array};
+use arrow::datatypes::FieldRef;
 use indexlake::catalog::Scalar;
 use indexlake::expr::{BinaryOp, Expr};
-use indexlake::index::{FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{
+    FilterIndexEntries, Index, IndexResultColumn, IndexResultOptions, SearchIndexEntries,
+    SearchQuery,
+};
 use indexlake::{ILError, ILResult};
 use uuid::Uuid;
 
@@ -40,18 +46,14 @@ impl PartialOrd for OrderedScalar {
 #[derive(Debug)]
 pub struct BTreeIndex {
     btree: BTreeMap<OrderedScalar, Vec<Uuid>>,
-}
-
-impl Default for BTreeIndex {
-    fn default() -> Self {
-        Self::new()
-    }
+    key_field: FieldRef,
 }
 
 impl BTreeIndex {
-    pub fn new() -> Self {
+    pub fn new(key_field: FieldRef) -> Self {
         Self {
             btree: BTreeMap::new(),
+            key_field,
         }
     }
 
@@ -60,21 +62,35 @@ impl BTreeIndex {
         Ok(())
     }
 
-    fn point_query(&self, point: &OrderedScalar) -> Vec<Uuid> {
-        self.btree.get(point).cloned().unwrap_or_default()
+    fn point_query(&self, point: &OrderedScalar) -> Vec<(Uuid, Scalar)> {
+        self.btree
+            .get(point)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|row_id| (row_id, point.0.clone()))
+            .collect()
     }
 
-    fn range_query(&self, range: (Bound<&OrderedScalar>, Bound<&OrderedScalar>)) -> Vec<Uuid> {
+    fn range_query(
+        &self,
+        range: (Bound<&OrderedScalar>, Bound<&OrderedScalar>),
+    ) -> Vec<(Uuid, Scalar)> {
         let mut results = Vec::new();
 
-        for (_, row_ids) in self.btree.range(range) {
-            results.extend_from_slice(row_ids);
+        for (key, row_ids) in self.btree.range(range) {
+            results.extend(
+                row_ids
+                    .iter()
+                    .copied()
+                    .map(|row_id| (row_id, key.0.clone())),
+            );
         }
 
         results
     }
 
-    fn evaluate_filter(&self, filter: &Expr) -> ILResult<Vec<Uuid>> {
+    fn evaluate_filter(&self, filter: &Expr) -> ILResult<Vec<(Uuid, Scalar)>> {
         match filter {
             // TODO: add between expr && combine expr && is null expr / is not null expr?
             Expr::BinaryExpr(binary_expr) => {
@@ -110,28 +126,96 @@ impl BTreeIndex {
 
 #[async_trait::async_trait]
 impl Index for BTreeIndex {
-    async fn search(&self, _query: &dyn SearchQuery) -> ILResult<SearchIndexEntries> {
+    async fn search(
+        &self,
+        _query: &dyn SearchQuery,
+        _options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "B-tree index does not support search",
         ))
     }
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries> {
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
                 row_ids: Vec::new(),
+                dynamic_columns: Vec::new(),
             });
         }
 
-        let mut result_row_ids = self.evaluate_filter(&filters[0])?;
+        let mut result_entries = self.evaluate_filter(&filters[0])?;
         for filter in &filters[1..] {
-            let filter_row_ids = self.evaluate_filter(filter)?;
+            let filter_row_ids = self
+                .evaluate_filter(filter)?
+                .into_iter()
+                .map(|(row_id, _)| row_id)
+                .collect::<Vec<_>>();
             // TODO: optimize this by using a set
-            result_row_ids.retain(|id| filter_row_ids.contains(id));
+            result_entries.retain(|(row_id, _)| filter_row_ids.contains(row_id));
+        }
+
+        let row_ids = result_entries
+            .iter()
+            .map(|(row_id, _)| *row_id)
+            .collect::<Vec<_>>();
+
+        let mut dynamic_columns = Vec::new();
+        for column in &options.columns {
+            match column.name.as_str() {
+                "index_key" => {
+                    let values = scalars_to_array(
+                        self.key_field.data_type(),
+                        result_entries
+                            .iter()
+                            .map(|(_, value)| value)
+                            .collect::<Vec<_>>()
+                            .as_slice(),
+                    )?;
+                    dynamic_columns.push(IndexResultColumn {
+                        field: Arc::new(
+                            self.key_field
+                                .as_ref()
+                                .clone()
+                                .with_name(&column.output_name),
+                        ),
+                        values,
+                    });
+                }
+                _ => {
+                    return Err(ILError::invalid_input(format!(
+                        "Unsupported result column `{}` for index kind `btree`",
+                        column.name
+                    )));
+                }
+            }
         }
 
         Ok(FilterIndexEntries {
-            row_ids: result_row_ids,
+            row_ids,
+            dynamic_columns,
         })
     }
+}
+
+fn scalars_to_array(
+    data_type: &arrow::datatypes::DataType,
+    values: &[&Scalar],
+) -> ILResult<ArrayRef> {
+    if values.is_empty() {
+        return Ok(new_null_array(data_type, 0));
+    }
+    let arrays = values
+        .iter()
+        .map(|value| value.to_array_of_size(1))
+        .collect::<ILResult<Vec<_>>>()?;
+    let arrays = arrays
+        .iter()
+        .map(|array| array.as_ref())
+        .collect::<Vec<_>>();
+    Ok(arrow::compute::concat(arrays.as_slice())?)
 }

--- a/indexes/btree/src/kind.rs
+++ b/indexes/btree/src/kind.rs
@@ -1,11 +1,11 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, FieldRef};
 use indexlake::expr::{BinaryOp, Expr};
 use indexlake::index::{
     FilterSupport, IndexBuilder, IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams,
-    SearchQuery,
+    RequestedIndexColumn, SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 use serde::{Deserialize, Serialize};
@@ -71,6 +71,30 @@ impl IndexKind for BTreeIndexKind {
         _query: &dyn SearchQuery,
     ) -> ILResult<bool> {
         Ok(false)
+    }
+
+    fn output_fields(
+        &self,
+        index_def: &IndexDefinition,
+        columns: &[RequestedIndexColumn],
+    ) -> ILResult<Vec<FieldRef>> {
+        let key_field = index_def
+            .key_fields()?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ILError::internal("B-tree index key field not found".to_string()))?;
+        columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "index_key" => Ok(Arc::new(
+                    key_field.as_ref().clone().with_name(&column.output_name),
+                )),
+                _ => Err(ILError::invalid_input(format!(
+                    "Unsupported result column `{}` for index kind `btree`",
+                    column.name
+                ))),
+            })
+            .collect()
     }
 
     fn supports_filter(

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -1,8 +1,14 @@
 use std::any::Any;
+use std::sync::Arc;
 
+use arrow::array::Float64Array;
+use arrow::datatypes::Field;
 use hnsw::Hnsw;
 use indexlake::expr::Expr;
-use indexlake::index::{FilterIndexEntries, Index, RowIdScore, SearchIndexEntries, SearchQuery};
+use indexlake::index::{
+    FilterIndexEntries, Index, IndexResultColumn, IndexResultOptions, RowIdScore,
+    SearchIndexEntries, SearchQuery,
+};
 use indexlake::{ILError, ILResult};
 use rand_pcg::Pcg64;
 use space::Knn;
@@ -49,7 +55,11 @@ impl std::fmt::Debug for HnswIndex {
 
 #[async_trait::async_trait]
 impl Index for HnswIndex {
-    async fn search(&self, query: &dyn SearchQuery) -> ILResult<SearchIndexEntries> {
+    async fn search(
+        &self,
+        query: &dyn SearchQuery,
+        options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries> {
         let query = query
             .as_any()
             .downcast_ref::<HnswSearchQuery>()
@@ -69,13 +79,44 @@ impl Index for HnswIndex {
                 score: neighbor.distance as f64,
             });
         }
+
+        let mut dynamic_columns = Vec::new();
+        for column in &options.columns {
+            match column.name.as_str() {
+                "distance" => dynamic_columns.push(IndexResultColumn {
+                    field: Arc::new(Field::new(
+                        &column.output_name,
+                        arrow::datatypes::DataType::Float64,
+                        false,
+                    )),
+                    values: Arc::new(Float64Array::from(
+                        row_id_scores
+                            .iter()
+                            .map(|row| row.score)
+                            .collect::<Vec<_>>(),
+                    )),
+                }),
+                _ => {
+                    return Err(ILError::invalid_input(format!(
+                        "Unsupported result column `{}` for index kind `hnsw`",
+                        column.name
+                    )));
+                }
+            }
+        }
+
         Ok(SearchIndexEntries {
             row_id_scores,
             score_higher_is_better: false,
+            dynamic_columns,
         })
     }
 
-    async fn filter(&self, _filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        _filters: &[Expr],
+        _options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries> {
         Err(ILError::not_supported("Hnsw index does not support filter"))
     }
 }

--- a/indexes/hnsw/src/kind.rs
+++ b/indexes/hnsw/src/kind.rs
@@ -1,11 +1,11 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Field, FieldRef};
 use indexlake::expr::Expr;
 use indexlake::index::{
     FilterSupport, IndexBuilder, IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams,
-    SearchQuery,
+    RequestedIndexColumn, SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,27 @@ impl IndexKind for HnswIndexKind {
             return Ok(false);
         };
         Ok(true)
+    }
+
+    fn output_fields(
+        &self,
+        _index_def: &IndexDefinition,
+        columns: &[RequestedIndexColumn],
+    ) -> ILResult<Vec<FieldRef>> {
+        columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "distance" => Ok(Arc::new(Field::new(
+                    &column.output_name,
+                    DataType::Float64,
+                    false,
+                ))),
+                _ => Err(ILError::invalid_input(format!(
+                    "Unsupported result column `{}` for index kind `hnsw`",
+                    column.name
+                ))),
+            })
+            .collect()
     }
 
     fn supports_filter(

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use indexlake::catalog::Scalar;
 use indexlake::expr::{Expr, Function};
-use indexlake::index::{FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{
+    FilterIndexEntries, Index, IndexResultOptions, SearchIndexEntries, SearchQuery,
+};
 use indexlake::{ILError, ILResult};
 use rstar::{AABB, RTree, RTreeObject};
 use uuid::Uuid;
@@ -31,16 +33,31 @@ pub struct RStarIndex {
 
 #[async_trait::async_trait]
 impl Index for RStarIndex {
-    async fn search(&self, _query: &dyn SearchQuery) -> ILResult<SearchIndexEntries> {
+    async fn search(
+        &self,
+        _query: &dyn SearchQuery,
+        _options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "RStar index does not support search",
         ))
     }
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries> {
+        if let Some(column) = options.columns.first() {
+            return Err(ILError::invalid_input(format!(
+                "Unsupported result column `{}` for index kind `rstar`",
+                column.name
+            )));
+        }
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
                 row_ids: Vec::new(),
+                dynamic_columns: Vec::new(),
             });
         }
 
@@ -60,6 +77,7 @@ impl Index for RStarIndex {
 
         Ok(FilterIndexEntries {
             row_ids: row_ids.into_iter().collect(),
+            dynamic_columns: Vec::new(),
         })
     }
 }

--- a/indexes/rstar/src/kind.rs
+++ b/indexes/rstar/src/kind.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, FieldRef};
 use serde::{Deserialize, Serialize};
 
 use geozero::wkb::WkbDialect as GeozeroWkbDialect;
@@ -8,7 +8,7 @@ use indexlake::catalog::Scalar;
 use indexlake::expr::{Expr, Function};
 use indexlake::index::{
     FilterSupport, IndexBuilder, IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams,
-    SearchQuery,
+    RequestedIndexColumn, SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 
@@ -60,6 +60,20 @@ impl IndexKind for RStarIndexKind {
         _query: &dyn SearchQuery,
     ) -> ILResult<bool> {
         Ok(false)
+    }
+
+    fn output_fields(
+        &self,
+        _index_def: &IndexDefinition,
+        columns: &[RequestedIndexColumn],
+    ) -> ILResult<Vec<FieldRef>> {
+        if let Some(column) = columns.first() {
+            return Err(ILError::invalid_input(format!(
+                "Unsupported result column `{}` for index kind `rstar`",
+                column.name
+            )));
+        }
+        Ok(Vec::new())
     }
 
     fn supports_filter(

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 use crate::ILResult;
 use crate::expr::Expr;
 use crate::storage::{InputFile, OutputFile};
+use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
+use arrow::datatypes::FieldRef;
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -28,6 +30,12 @@ pub trait IndexKind: Debug + Send + Sync {
         index_def: &IndexDefinition,
         query: &dyn SearchQuery,
     ) -> ILResult<bool>;
+
+    fn output_fields(
+        &self,
+        index_def: &IndexDefinition,
+        columns: &[RequestedIndexColumn],
+    ) -> ILResult<Vec<FieldRef>>;
 
     fn supports_filter(
         &self,
@@ -55,15 +63,54 @@ pub trait IndexBuilder: Debug + Send + Sync {
 
 #[async_trait::async_trait]
 pub trait Index: Debug + Send + Sync {
-    async fn search(&self, query: &dyn SearchQuery) -> ILResult<SearchIndexEntries>;
+    async fn search(
+        &self,
+        query: &dyn SearchQuery,
+        options: &IndexResultOptions,
+    ) -> ILResult<SearchIndexEntries>;
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries>;
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        options: &IndexResultOptions,
+    ) -> ILResult<FilterIndexEntries>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct IndexResultOptions {
+    pub columns: Vec<RequestedIndexColumn>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestedIndexColumn {
+    pub name: String,
+    pub output_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexColumnRequest {
+    pub index_name: Option<String>,
+    pub name: String,
+    pub alias: Option<String>,
+}
+
+impl IndexColumnRequest {
+    pub fn output_name(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexResultColumn {
+    pub field: FieldRef,
+    pub values: ArrayRef,
 }
 
 #[derive(Debug, Clone)]
 pub struct SearchIndexEntries {
     pub row_id_scores: Vec<RowIdScore>,
     pub score_higher_is_better: bool,
+    pub dynamic_columns: Vec<IndexResultColumn>,
 }
 
 #[derive(Debug, Clone)]
@@ -75,6 +122,7 @@ pub struct RowIdScore {
 #[derive(Debug, Clone)]
 pub struct FilterIndexEntries {
     pub row_ids: Vec<Uuid>,
+    pub dynamic_columns: Vec<IndexResultColumn>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -6,7 +7,7 @@ use std::task::{Context, Poll};
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
-use arrow_schema::Schema;
+use arrow_schema::{FieldRef, Schema};
 use futures::{Stream, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -16,16 +17,22 @@ use crate::catalog::{
     rows_to_record_batch,
 };
 use crate::expr::{Expr, merge_filters, row_ids_in_list_expr, split_conjunction_filters};
-use crate::index::{FilterSupport, IndexManager};
+use crate::index::{
+    FilterSupport, IndexColumnRequest, IndexManager, IndexResultOptions, RequestedIndexColumn,
+};
 use crate::storage::{Storage, count_data_file_by_record, read_data_file_by_record};
 use crate::table::{Table, TableSchemaRef};
-use crate::utils::project_schema;
+use crate::utils::{
+    DynamicColumnLookup, append_columns_to_record_batch, extract_row_ids_from_record_batch,
+    gather_index_result_columns, project_schema, validate_index_result_columns,
+};
 use crate::{ILError, ILResult, RecordBatchStream};
 
 #[derive(Debug, Clone, derive_with::With)]
 pub struct TableScan {
     pub projection: Option<Vec<usize>>,
     pub filters: Vec<Expr>,
+    pub index_columns: Vec<IndexColumnRequest>,
     pub batch_size: usize,
     pub partition: TableScanPartition,
     pub offset: usize,
@@ -77,6 +84,7 @@ impl Default for TableScan {
         Self {
             projection: None,
             filters: vec![],
+            index_columns: vec![],
             batch_size: 1024,
             partition: TableScanPartition::single_partition(),
             offset: 0,
@@ -156,6 +164,18 @@ impl TableScanPartition {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct IndexDynamicResultPlan {
+    options: IndexResultOptions,
+    fields: Vec<FieldRef>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ScanDynamicResultPlan {
+    per_index: HashMap<String, IndexDynamicResultPlan>,
+    output_fields: Vec<FieldRef>,
+}
+
 pub(crate) async fn process_scan(
     catalog_helper: &CatalogHelper,
     table: &Table,
@@ -165,14 +185,27 @@ pub(crate) async fn process_scan(
     scan.filters = filters;
 
     let index_filter_assignment = assign_index_filters(&table.index_manager, &scan.filters)?;
+    let dynamic_result_plan =
+        resolve_scan_dynamic_result_plan(table, &scan, &index_filter_assignment)?;
 
     if index_filter_assignment
         .values()
         .any(|filters| !filters.is_empty())
     {
-        process_index_scan(catalog_helper, table, scan, index_filter_assignment).await
-    } else {
+        process_index_scan(
+            catalog_helper,
+            table,
+            scan,
+            index_filter_assignment,
+            dynamic_result_plan,
+        )
+        .await
+    } else if scan.index_columns.is_empty() {
         process_table_scan(catalog_helper, table, scan).await
+    } else {
+        Err(ILError::invalid_input(
+            "index_columns requires at least one filter assigned to an index".to_string(),
+        ))
     }
 }
 
@@ -345,6 +378,7 @@ async fn process_index_scan(
     table: &Table,
     scan: TableScan,
     index_filter_assignment: HashMap<String, Vec<usize>>,
+    dynamic_result_plan: ScanDynamicResultPlan,
 ) -> ILResult<RecordBatchStream> {
     let non_index_filters = scan
         .filters
@@ -366,6 +400,7 @@ async fn process_index_scan(
             &scan,
             &index_filter_assignment,
             &non_index_filters,
+            &dynamic_result_plan,
         )
         .await?;
         vec![inline_rows_stream]
@@ -374,7 +409,8 @@ async fn process_index_scan(
     };
 
     let data_file_records =
-        get_partitioned_data_file_records(catalog_helper, &table.table_id, scan.partition).await?;
+        get_partitioned_data_file_records(catalog_helper, &table.table_id, scan.partition.clone())
+            .await?;
 
     let mut futs = Vec::with_capacity(data_file_records.len());
     for data_file_record in data_file_records {
@@ -384,6 +420,7 @@ async fn process_index_scan(
         let scan_filters = scan.filters.clone();
         let scan_batch_size = scan.batch_size;
         let index_filter_assignment = index_filter_assignment.clone();
+        let dynamic_result_plan = dynamic_result_plan.clone();
         let fut = async move {
             index_scan_data_file(
                 &catalog_helper,
@@ -393,6 +430,7 @@ async fn process_index_scan(
                 scan_batch_size,
                 &data_file_record,
                 &index_filter_assignment,
+                &dynamic_result_plan,
             )
             .await
         };
@@ -401,8 +439,16 @@ async fn process_index_scan(
     let stream = futures::stream::iter(futs).buffered(1).try_flatten();
 
     streams.push(Box::pin(stream));
-
-    Ok(Box::pin(futures::stream::select_all(streams)))
+    let stream: RecordBatchStream = Box::pin(futures::stream::select_all(streams));
+    if scan.offset_limit_required() {
+        Ok(Box::pin(LimitOffsetRecordBatchStream::new(
+            stream,
+            scan.offset,
+            scan.limit,
+        )))
+    } else {
+        Ok(stream)
+    }
 }
 
 async fn index_scan_inline_rows(
@@ -411,6 +457,7 @@ async fn index_scan_inline_rows(
     scan: &TableScan,
     index_filter_assignment: &HashMap<String, Vec<usize>>,
     non_index_filters: &[Expr],
+    dynamic_result_plan: &ScanDynamicResultPlan,
 ) -> ILResult<RecordBatchStream> {
     let mut index_builder_map = HashMap::new();
     let mut index_ids = Vec::new();
@@ -453,6 +500,7 @@ async fn index_scan_inline_rows(
 
     // filter row ids by indexes
     let mut filter_index_entries_list = Vec::new();
+    let mut dynamic_lookup_map = HashMap::new();
     for (index_name, filter_indices) in index_filter_assignment.iter() {
         let index_builder = index_builder_map.get_mut(index_name).ok_or_else(|| {
             ILError::internal(format!("Index builder not found for index {index_name}"))
@@ -465,7 +513,25 @@ async fn index_scan_inline_rows(
             .map(|idx| scan.filters[*idx].clone())
             .collect::<Vec<_>>();
 
-        let filter_index_entries = index.filter(&filters).await?;
+        let index_result_plan = dynamic_result_plan
+            .per_index
+            .get(index_name)
+            .cloned()
+            .unwrap_or_default();
+        let filter_index_entries = index.filter(&filters, &index_result_plan.options).await?;
+        validate_index_result_columns(
+            &filter_index_entries.dynamic_columns,
+            &index_result_plan.fields,
+            filter_index_entries.row_ids.len(),
+        )?;
+        let row_ids = filter_index_entries.row_ids.clone();
+        let lookups =
+            build_dynamic_column_lookups(&row_ids, filter_index_entries.dynamic_columns.clone())?;
+        dynamic_lookup_map.extend(
+            lookups
+                .into_iter()
+                .map(|lookup| (lookup.field.name().clone(), lookup)),
+        );
         filter_index_entries_list.push(filter_index_entries);
     }
 
@@ -498,10 +564,11 @@ async fn index_scan_inline_rows(
             None,
         )
         .await?;
+    let output_fields = dynamic_result_plan.output_fields.clone();
     let inline_stream = row_stream.chunks(scan.batch_size).map(move |rows| {
         let rows = rows.into_iter().collect::<ILResult<Vec<_>>>()?;
         let batch = rows_to_record_batch(&projected_schema, &rows)?;
-        Ok::<_, ILError>(batch)
+        append_requested_dynamic_columns(&batch, &dynamic_lookup_map, &output_fields)
     });
 
     Ok(Box::pin(inline_stream) as RecordBatchStream)
@@ -515,6 +582,7 @@ async fn index_scan_data_file(
     scan_batch_size: usize,
     data_file_record: &DataFileRecord,
     index_filter_assignment: &HashMap<String, Vec<usize>>,
+    dynamic_result_plan: &ScanDynamicResultPlan,
 ) -> ILResult<RecordBatchStream> {
     let index_file_records = catalog_helper
         .get_index_files_by_data_file_id(&data_file_record.data_file_id)
@@ -523,11 +591,12 @@ async fn index_scan_data_file(
         .iter()
         .map(|record| (record.index_id, record))
         .collect::<HashMap<_, _>>();
-    let row_ids = filter_index_files_row_ids(
+    let index_filter_result = filter_index_files_row_ids(
         table,
         scan_filters,
         &index_file_records_map,
         index_filter_assignment,
+        dynamic_result_plan,
     )
     .await?;
 
@@ -542,10 +611,10 @@ async fn index_scan_data_file(
         .map(|(_, filter)| filter.clone())
         .collect::<Vec<_>>();
 
-    let row_id_filter = row_ids_in_list_expr(row_ids.into_iter().collect());
+    let row_id_filter = row_ids_in_list_expr(index_filter_result.row_ids.into_iter().collect());
     left_filters.push(row_id_filter);
 
-    read_data_file_by_record(
+    let stream = read_data_file_by_record(
         table.storage.as_ref(),
         &table.table_schema,
         data_file_record,
@@ -553,7 +622,22 @@ async fn index_scan_data_file(
         left_filters,
         scan_batch_size,
     )
-    .await
+    .await?;
+    if index_filter_result.lookups.is_empty() {
+        Ok(stream)
+    } else {
+        let lookup_map = index_filter_result
+            .lookups
+            .into_iter()
+            .map(|lookup| (lookup.field.name().clone(), lookup))
+            .collect::<HashMap<_, _>>();
+        let output_fields = dynamic_result_plan.output_fields.clone();
+        let stream = stream.map(move |batch| {
+            let batch = batch?;
+            append_requested_dynamic_columns(&batch, &lookup_map, &output_fields)
+        });
+        Ok(Box::pin(stream))
+    }
 }
 
 async fn filter_index_files_row_ids(
@@ -561,8 +645,10 @@ async fn filter_index_files_row_ids(
     filters: &[Expr],
     index_file_records: &HashMap<Uuid, &IndexFileRecord>,
     index_filter_assignment: &HashMap<String, Vec<usize>>,
-) -> ILResult<HashSet<Uuid>> {
+    dynamic_result_plan: &ScanDynamicResultPlan,
+) -> ILResult<IndexFilterResult> {
     let mut filter_index_entries_list = Vec::new();
+    let mut dynamic_lookup_map = HashMap::new();
     for (index_name, filter_indices) in index_filter_assignment.iter() {
         let index_def = table
             .index_manager
@@ -592,7 +678,25 @@ async fn filter_index_files_row_ids(
 
         let index = index_builder.build()?;
 
-        let filter_index_entries = index.filter(&filters).await?;
+        let index_result_plan = dynamic_result_plan
+            .per_index
+            .get(index_name)
+            .cloned()
+            .unwrap_or_default();
+        let filter_index_entries = index.filter(&filters, &index_result_plan.options).await?;
+        validate_index_result_columns(
+            &filter_index_entries.dynamic_columns,
+            &index_result_plan.fields,
+            filter_index_entries.row_ids.len(),
+        )?;
+        let row_ids = filter_index_entries.row_ids.clone();
+        let lookups =
+            build_dynamic_column_lookups(&row_ids, filter_index_entries.dynamic_columns.clone())?;
+        dynamic_lookup_map.extend(
+            lookups
+                .into_iter()
+                .map(|lookup| (lookup.field.name().clone(), lookup)),
+        );
         filter_index_entries_list.push(filter_index_entries);
     }
 
@@ -605,7 +709,23 @@ async fn filter_index_files_row_ids(
         intersected_row_ids = intersected_row_ids.intersection(&set).cloned().collect();
     }
 
-    Ok(intersected_row_ids.into_iter().copied().collect())
+    let lookups = dynamic_result_plan
+        .output_fields
+        .iter()
+        .map(|field| {
+            dynamic_lookup_map.remove(field.name()).ok_or_else(|| {
+                ILError::internal(format!(
+                    "Dynamic column lookup not found for {}",
+                    field.name()
+                ))
+            })
+        })
+        .collect::<ILResult<Vec<_>>>()?;
+
+    Ok(IndexFilterResult {
+        row_ids: intersected_row_ids.into_iter().copied().collect(),
+        lookups,
+    })
 }
 
 fn assign_index_filters(
@@ -636,6 +756,226 @@ fn assign_index_filters(
         }
     }
     Ok(index_filter_assignment)
+}
+
+fn resolve_scan_dynamic_result_plan(
+    table: &Table,
+    scan: &TableScan,
+    index_filter_assignment: &HashMap<String, Vec<usize>>,
+) -> ILResult<ScanDynamicResultPlan> {
+    if scan.index_columns.is_empty() {
+        return Ok(ScanDynamicResultPlan::default());
+    }
+
+    let participating_indexes = index_filter_assignment
+        .iter()
+        .filter(|(_, filter_indices)| !filter_indices.is_empty())
+        .map(|(index_name, _)| index_name.clone())
+        .collect::<Vec<_>>();
+    if participating_indexes.is_empty() {
+        return Err(ILError::invalid_input(
+            "index_columns requires at least one filter assigned to an index".to_string(),
+        ));
+    }
+
+    let projected_schema = project_schema(&table.output_schema, scan.projection.as_ref())?;
+    let mut output_names = projected_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<HashSet<_>>();
+
+    let mut grouped_columns: HashMap<String, Vec<RequestedIndexColumn>> = HashMap::new();
+    let mut ordered_output_names = Vec::with_capacity(scan.index_columns.len());
+
+    for column in &scan.index_columns {
+        let target_index = if let Some(index_name) = &column.index_name {
+            if !participating_indexes.contains(index_name) {
+                return Err(ILError::invalid_input(format!(
+                    "Scan result column `{}` targets index `{index_name}`, but that index does not participate in this scan",
+                    column.name
+                )));
+            }
+            index_name.clone()
+        } else if participating_indexes.len() == 1 {
+            participating_indexes[0].clone()
+        } else {
+            return Err(ILError::invalid_input(format!(
+                "Scan result column `{}` must specify index_name because multiple indexes participate in this scan",
+                column.name
+            )));
+        };
+
+        let output_name = column.output_name().to_string();
+        if !output_names.insert(output_name.clone()) {
+            return Err(ILError::invalid_input(format!(
+                "Duplicate output column name `{output_name}` in scan result"
+            )));
+        }
+
+        grouped_columns
+            .entry(target_index)
+            .or_default()
+            .push(RequestedIndexColumn {
+                name: column.name.clone(),
+                output_name,
+            });
+        ordered_output_names.push(column.output_name().to_string());
+    }
+
+    let mut per_index = HashMap::new();
+    for (index_name, columns) in grouped_columns {
+        let index_def = table
+            .index_manager
+            .get_index(&index_name)
+            .ok_or_else(|| ILError::internal(format!("Index {index_name} not found")))?;
+        let index_kind = table
+            .index_manager
+            .get_index_kind(&index_def.kind)
+            .ok_or_else(|| {
+                ILError::internal(format!("Index kind {} not registered", index_def.kind))
+            })?;
+        let fields = index_kind.output_fields(index_def.as_ref(), &columns)?;
+        per_index.insert(
+            index_name,
+            IndexDynamicResultPlan {
+                options: IndexResultOptions { columns },
+                fields,
+            },
+        );
+    }
+
+    let output_fields = ordered_output_names
+        .iter()
+        .map(|name| {
+            per_index
+                .values()
+                .flat_map(|plan| plan.fields.iter())
+                .find(|field| field.name() == name)
+                .cloned()
+                .ok_or_else(|| {
+                    ILError::internal(format!(
+                        "Dynamic output field {name} not found after scan plan resolution"
+                    ))
+                })
+        })
+        .collect::<ILResult<Vec<_>>>()?;
+
+    Ok(ScanDynamicResultPlan {
+        per_index,
+        output_fields,
+    })
+}
+
+fn build_dynamic_column_lookups(
+    row_ids: &[Uuid],
+    dynamic_columns: Vec<crate::index::IndexResultColumn>,
+) -> ILResult<Vec<DynamicColumnLookup>> {
+    dynamic_columns
+        .into_iter()
+        .map(|column| DynamicColumnLookup::try_new(column.field, row_ids, column.values))
+        .collect()
+}
+
+fn append_requested_dynamic_columns(
+    batch: &RecordBatch,
+    lookup_map: &HashMap<String, DynamicColumnLookup>,
+    output_fields: &[FieldRef],
+) -> ILResult<RecordBatch> {
+    if output_fields.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    let row_ids = extract_row_ids_from_record_batch(batch)?;
+    let lookups = output_fields
+        .iter()
+        .map(|field| {
+            lookup_map.get(field.name()).cloned().ok_or_else(|| {
+                ILError::internal(format!(
+                    "Dynamic column lookup not found for {}",
+                    field.name()
+                ))
+            })
+        })
+        .collect::<ILResult<Vec<_>>>()?;
+    let columns = gather_index_result_columns(&row_ids, &lookups)?;
+    append_columns_to_record_batch(batch, &columns)
+}
+
+#[derive(Debug)]
+struct IndexFilterResult {
+    row_ids: HashSet<Uuid>,
+    lookups: Vec<DynamicColumnLookup>,
+}
+
+struct LimitOffsetRecordBatchStream {
+    stream: RecordBatchStream,
+    query_window: Range<usize>,
+    row_pointer: usize,
+}
+
+impl LimitOffsetRecordBatchStream {
+    fn new(stream: RecordBatchStream, offset: usize, limit: Option<usize>) -> Self {
+        let query_window = if let Some(limit) = limit {
+            offset..offset + limit
+        } else {
+            offset..usize::MAX
+        };
+        Self {
+            stream,
+            query_window,
+            row_pointer: 0,
+        }
+    }
+
+    fn apply_limit_offset(&self, batch: RecordBatch) -> RecordBatch {
+        let num_rows = batch.num_rows();
+        if num_rows == 0 {
+            return batch;
+        }
+
+        let batch_range = self.row_pointer..self.row_pointer + num_rows;
+        let intersection_start = batch_range.start.max(self.query_window.start);
+        let intersection_end = batch_range.end.min(self.query_window.end);
+        if intersection_start >= intersection_end {
+            return RecordBatch::new_empty(batch.schema());
+        }
+
+        let slice_start = intersection_start - batch_range.start;
+        let slice_len = intersection_end - intersection_start;
+        if slice_start == 0 && slice_len == num_rows {
+            batch
+        } else {
+            batch.slice(slice_start, slice_len)
+        }
+    }
+}
+
+impl Stream for LimitOffsetRecordBatchStream {
+    type Item = ILResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            if self.row_pointer >= self.query_window.end {
+                return Poll::Ready(None);
+            }
+
+            let stream = Pin::new(&mut self.stream);
+            match stream.poll_next(cx) {
+                Poll::Ready(Some(Ok(batch))) => {
+                    let num_rows = batch.num_rows();
+                    let batch = self.apply_limit_offset(batch);
+                    self.row_pointer += num_rows;
+                    if batch.num_rows() > 0 {
+                        return Poll::Ready(Some(Ok(batch)));
+                    }
+                }
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
 }
 
 type GettingDataFileStreamFut =

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -10,28 +10,36 @@ use crate::catalog::{
     CatalogHelper, CatalogSchema, DataFileRecord, IndexFileRecord, Row, rows_to_record_batch,
 };
 use crate::expr::row_ids_in_list_expr;
-use crate::index::{IndexDefinitionRef, IndexKind, RowIdScore, SearchIndexEntries, SearchQuery};
+use crate::index::{
+    IndexColumnRequest, IndexDefinitionRef, IndexKind, IndexResultColumn, IndexResultOptions,
+    RequestedIndexColumn, RowIdScore, SearchIndexEntries, SearchQuery,
+};
 use crate::storage::{Storage, read_data_file_by_record};
 use crate::table::Table;
-use crate::utils::project_schema;
+use crate::utils::{
+    append_columns_to_record_batch, concat_index_result_columns, project_schema,
+    reorder_index_result_columns, validate_index_result_columns,
+};
 use crate::{ILError, ILResult, RecordBatchStream};
+use arrow_schema::FieldRef;
 
 #[derive(Debug, Clone)]
 pub struct TableSearch {
     pub query: Arc<dyn SearchQuery>,
     pub projection: Option<Vec<usize>>,
+    pub index_columns: Vec<IndexColumnRequest>,
 }
 
 pub(crate) async fn process_search(
     table: &Table,
     search: TableSearch,
 ) -> ILResult<RecordBatchStream> {
-    let index_kind = search.query.index_kind();
+    let index_kind_name = search.query.index_kind();
 
     let (index_def, index_kind) = table
         .index_manager
         .iter_index_and_kind()
-        .find(|(index_def, _)| index_def.kind == index_kind)
+        .find(|(index_def, _)| index_def.kind == index_kind_name)
         .ok_or_else(|| {
             ILError::index(format!(
                 "Index not found for search query: {:?}",
@@ -39,18 +47,29 @@ pub(crate) async fn process_search(
             ))
         })?;
 
+    let requested_columns =
+        resolve_search_columns(table, &search, index_def.as_ref(), index_kind.as_ref())?;
+    let dynamic_fields = index_kind.output_fields(index_def.as_ref(), &requested_columns)?;
+    let result_options = IndexResultOptions {
+        columns: requested_columns,
+    };
+
     let catalog_helper = CatalogHelper::new(table.catalog.clone());
 
     let catalog_helper_captured = catalog_helper.clone();
     let index_kind_captured = index_kind.clone();
     let index_def_captured = index_def.clone();
     let search_captured = search.clone();
+    let result_options_captured = result_options.clone();
+    let dynamic_fields_captured = dynamic_fields.clone();
     let inline_handle = tokio::spawn(async move {
         let inline_search_entries = search_inline_rows(
             &catalog_helper_captured,
             index_kind_captured.as_ref(),
             &index_def_captured,
             &search_captured,
+            &result_options_captured,
+            &dynamic_fields_captured,
         )
         .await?;
         Ok::<_, ILError>(inline_search_entries)
@@ -68,6 +87,8 @@ pub(crate) async fn process_search(
         let index_kind = index_kind.clone();
         let index_def = index_def.clone();
         let search_query = search.query.clone();
+        let result_options = result_options.clone();
+        let dynamic_fields = dynamic_fields.clone();
         let handle = tokio::spawn(async move {
             let index_file_record = catalog_helper
                 .get_index_file_by_index_id_and_data_file_id(&index_id, &data_file_id)
@@ -82,6 +103,8 @@ pub(crate) async fn process_search(
                 &index_def,
                 search_query.as_ref(),
                 &index_file_record,
+                &result_options,
+                &dynamic_fields,
             )
             .await?;
             Ok::<_, ILError>((data_file_id, search_entries))
@@ -91,46 +114,89 @@ pub(crate) async fn process_search(
 
     let join_all = futures::future::join_all(handles).await;
 
-    let mut index_file_search_entries = HashMap::with_capacity(join_all.len());
+    let mut search_entries = Vec::with_capacity(join_all.len() + 1);
+    let inline_search_entries = inline_handle.await??;
+    search_entries.push((RowLocation::Inline, inline_search_entries));
+
     for res in join_all {
-        let (data_file_id, search_entries) = res??;
-        index_file_search_entries.insert(data_file_id, search_entries);
+        let (data_file_id, entries) = res??;
+        search_entries.push((RowLocation::DataFile(data_file_id), entries));
     }
 
-    let inline_search_entries = inline_handle.await??;
-
-    let score_higher_is_better = inline_search_entries.score_higher_is_better;
-
-    let row_id_score_locations = merge_search_index_entries(
-        inline_search_entries,
-        index_file_search_entries,
-        search.query.limit(),
-    )?;
+    let merged_entries = merge_search_index_entries(search_entries, &dynamic_fields)?;
 
     let inline_batch = read_inline_rows(
         &catalog_helper,
         table,
-        &row_id_score_locations,
+        &merged_entries.row_id_score_locations,
         search.projection.clone(),
     )
     .await?;
 
     let data_file_batches = read_data_file_rows(
         table,
-        &row_id_score_locations,
+        &merged_entries.row_id_score_locations,
         search.projection.clone(),
         &data_file_records,
     )
     .await?;
 
-    let sorted_batch = sort_batches(
+    let (sorted_batch, sort_indices) = sort_batches(
         inline_batch,
         data_file_batches,
-        &row_id_score_locations,
-        score_higher_is_better,
+        &merged_entries.row_id_score_locations,
+        merged_entries.score_higher_is_better,
+        search.query.limit(),
     )?;
+    let sorted_dynamic_columns =
+        reorder_index_result_columns(&merged_entries.dynamic_columns, &sort_indices)?;
+    let final_batch = append_columns_to_record_batch(&sorted_batch, &sorted_dynamic_columns)?;
 
-    Ok(Box::pin(futures::stream::iter(vec![Ok(sorted_batch)])))
+    Ok(Box::pin(futures::stream::iter(vec![Ok(final_batch)])))
+}
+
+fn resolve_search_columns(
+    table: &Table,
+    search: &TableSearch,
+    index_def: &crate::index::IndexDefinition,
+    index_kind: &dyn IndexKind,
+) -> ILResult<Vec<RequestedIndexColumn>> {
+    let projected_schema = project_schema(&table.output_schema, search.projection.as_ref())?;
+    let mut output_names = projected_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<std::collections::HashSet<_>>();
+
+    let requested_columns = search
+        .index_columns
+        .iter()
+        .map(|column| {
+            if let Some(index_name) = &column.index_name
+                && index_name != &index_def.name
+            {
+                return Err(ILError::invalid_input(format!(
+                    "Search result column `{}` targets index `{index_name}`, but the search uses index `{}`",
+                    column.name, index_def.name
+                )));
+            }
+
+            let output_name = column.output_name().to_string();
+            if !output_names.insert(output_name.clone()) {
+                return Err(ILError::invalid_input(format!(
+                    "Duplicate output column name `{output_name}` in search result"
+                )));
+            }
+
+            Ok(RequestedIndexColumn {
+                name: column.name.clone(),
+                output_name,
+            })
+        })
+        .collect::<ILResult<Vec<_>>>()?;
+
+    let _ = index_kind.output_fields(index_def, &requested_columns)?;
+    Ok(requested_columns)
 }
 
 async fn search_inline_rows(
@@ -138,6 +204,8 @@ async fn search_inline_rows(
     index_kind: &dyn IndexKind,
     index_def: &IndexDefinitionRef,
     search: &TableSearch,
+    result_options: &IndexResultOptions,
+    dynamic_fields: &[FieldRef],
 ) -> ILResult<SearchIndexEntries> {
     let mut index_builder = index_kind.builder(index_def)?;
 
@@ -151,7 +219,12 @@ async fn search_inline_rows(
 
     let index = index_builder.build()?;
 
-    let search_index_entries = index.search(search.query.as_ref()).await?;
+    let search_index_entries = index.search(search.query.as_ref(), result_options).await?;
+    validate_index_result_columns(
+        &search_index_entries.dynamic_columns,
+        dynamic_fields,
+        search_index_entries.row_id_scores.len(),
+    )?;
 
     Ok(search_index_entries)
 }
@@ -162,6 +235,8 @@ async fn search_index_file(
     index_def: &IndexDefinitionRef,
     search_query: &dyn SearchQuery,
     index_file_record: &IndexFileRecord,
+    result_options: &IndexResultOptions,
+    dynamic_fields: &[FieldRef],
 ) -> ILResult<SearchIndexEntries> {
     let index_file = storage.open(&index_file_record.relative_path).await?;
 
@@ -170,48 +245,64 @@ async fn search_index_file(
 
     let index = index_builder.build()?;
 
-    let search_index_entries = index.search(search_query).await?;
+    let search_index_entries = index.search(search_query, result_options).await?;
+    validate_index_result_columns(
+        &search_index_entries.dynamic_columns,
+        dynamic_fields,
+        search_index_entries.row_id_scores.len(),
+    )?;
 
     Ok(search_index_entries)
 }
 
 fn merge_search_index_entries(
-    inline_search_entries: SearchIndexEntries,
-    index_file_search_entries: HashMap<Uuid, SearchIndexEntries>,
-    limit: Option<usize>,
-) -> ILResult<Vec<(RowIdScore, RowLocation)>> {
+    search_entries: Vec<(RowLocation, SearchIndexEntries)>,
+    dynamic_fields: &[FieldRef],
+) -> ILResult<MergedSearchEntries> {
     let mut row_id_score_locations = Vec::new();
-    for row_id_score in inline_search_entries.row_id_scores.into_iter() {
-        row_id_score_locations.push((row_id_score, RowLocation::Inline));
-    }
-    for (data_file_id, search_index_entries) in index_file_search_entries.into_iter() {
-        for row_id_score in search_index_entries.row_id_scores.into_iter() {
-            row_id_score_locations.push((row_id_score, RowLocation::DataFile(data_file_id)));
+    let mut dynamic_column_groups = Vec::new();
+    let mut score_higher_is_better = None;
+
+    for (location, search_entries) in search_entries {
+        if let Some(current) = score_higher_is_better {
+            if current != search_entries.score_higher_is_better {
+                return Err(ILError::internal(
+                    "Search index entries disagree on score ordering",
+                ));
+            }
+        } else {
+            score_higher_is_better = Some(search_entries.score_higher_is_better);
+        }
+
+        validate_index_result_columns(
+            &search_entries.dynamic_columns,
+            dynamic_fields,
+            search_entries.row_id_scores.len(),
+        )?;
+
+        dynamic_column_groups.push(search_entries.dynamic_columns.clone());
+        for row_id_score in search_entries.row_id_scores {
+            row_id_score_locations.push((row_id_score, location.clone()));
         }
     }
 
-    if inline_search_entries.score_higher_is_better {
-        row_id_score_locations.sort_by(|a, b| {
-            b.0.score
-                .partial_cmp(&a.0.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        row_id_score_locations.sort_by(|a, b| {
-            a.0.score
-                .partial_cmp(&b.0.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let dynamic_columns = concat_index_result_columns(&dynamic_column_groups, dynamic_fields)?;
 
-    if let Some(limit) = limit {
-        row_id_score_locations.truncate(limit);
-    }
-
-    Ok(row_id_score_locations)
+    Ok(MergedSearchEntries {
+        row_id_score_locations,
+        dynamic_columns,
+        score_higher_is_better: score_higher_is_better.unwrap_or(true),
+    })
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+struct MergedSearchEntries {
+    row_id_score_locations: Vec<(RowIdScore, RowLocation)>,
+    dynamic_columns: Vec<IndexResultColumn>,
+    score_higher_is_better: bool,
+}
+
+#[derive(Debug, Clone)]
 enum RowLocation {
     Inline,
     DataFile(Uuid),
@@ -298,13 +389,19 @@ fn sort_batches(
     data_file_batches: Vec<RecordBatch>,
     row_id_score_locations: &[(RowIdScore, RowLocation)],
     score_higher_is_better: bool,
-) -> ILResult<RecordBatch> {
+    limit: Option<usize>,
+) -> ILResult<(RecordBatch, arrow::array::UInt32Array)> {
     let mut batch = inline_batch;
     for data_file_batch in data_file_batches {
         batch = arrow::compute::concat_batches(&batch.schema(), [&batch, &data_file_batch])?;
     }
 
-    let mut scores = Vec::new();
+    let mut row_id_to_score = HashMap::with_capacity(row_id_score_locations.len());
+    for (row_id_score, _) in row_id_score_locations {
+        row_id_to_score.insert(row_id_score.row_id, row_id_score.score);
+    }
+
+    let mut scores = Vec::with_capacity(batch.num_rows());
     let row_id_array = batch
         .column(0)
         .as_any()
@@ -313,21 +410,26 @@ fn sort_batches(
     for row_id in row_id_array.iter() {
         let row_id_bytes = row_id.ok_or(ILError::index("Row id is null"))?;
         let row_id = Uuid::from_slice(row_id_bytes)?;
-        let row_id_score = row_id_score_locations
-            .iter()
-            .find(|(row_id_score, _)| row_id_score.row_id == row_id)
+        let score = row_id_to_score
+            .get(&row_id)
+            .copied()
             .ok_or(ILError::index(format!(
                 "Row id score not found for row id {row_id}"
             )))?;
-        scores.push(row_id_score.0.score);
+        scores.push(score);
     }
 
     let scores_array = Float64Array::from(scores);
 
     let sort_options = SortOptions::default().with_descending(score_higher_is_better);
-    let indices = arrow::compute::sort_to_indices(&scores_array, Some(sort_options), None)?;
+    let mut indices = arrow::compute::sort_to_indices(&scores_array, Some(sort_options), None)?;
+    if let Some(limit) = limit
+        && indices.len() > limit
+    {
+        indices = arrow::array::UInt32Array::from(indices.values()[0..limit].to_vec());
+    }
 
     let batch = arrow::compute::take_record_batch(&batch, &indices)?;
 
-    Ok(batch)
+    Ok((batch, indices))
 }

--- a/indexlake/src/utils.rs
+++ b/indexlake/src/utils.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use arrow::array::{
-    Array, ArrayRef, AsArray, FixedSizeBinaryArray, RecordBatch, RecordBatchOptions,
+    Array, ArrayRef, AsArray, FixedSizeBinaryArray, RecordBatch, RecordBatchOptions, UInt32Array,
+    new_null_array,
 };
 use arrow::datatypes::{FieldRef, Schema};
 use arrow::ipc::reader::StreamReader;
@@ -12,6 +13,7 @@ use uuid::Uuid;
 
 use crate::catalog::INTERNAL_ROW_ID_FIELD_NAME;
 use crate::expr::{Expr, visited_columns};
+use crate::index::IndexResultColumn;
 use crate::{ILError, ILResult};
 
 pub fn schema_without_row_id(schema: &Schema) -> Schema {
@@ -185,6 +187,218 @@ pub fn rewrite_batch_schema(
         Arc::new(Schema::new(new_fields).with_metadata(batch_schema.metadata().clone()));
     let new_batch = RecordBatch::try_new(new_schema, batch.columns().to_vec())?;
     Ok(new_batch)
+}
+
+pub fn append_columns_to_record_batch(
+    batch: &RecordBatch,
+    columns: &[IndexResultColumn],
+) -> ILResult<RecordBatch> {
+    if columns.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    let mut fields = batch.schema().fields().iter().cloned().collect::<Vec<_>>();
+    let mut arrays = batch.columns().to_vec();
+
+    for column in columns {
+        if column.values.len() != batch.num_rows() {
+            return Err(ILError::internal(format!(
+                "Dynamic column {} length {} does not match batch row count {}",
+                column.field.name(),
+                column.values.len(),
+                batch.num_rows()
+            )));
+        }
+        fields.push(column.field.clone());
+        arrays.push(column.values.clone());
+    }
+
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        batch.schema().metadata().clone(),
+    ));
+    Ok(RecordBatch::try_new(schema, arrays)?)
+}
+
+pub fn reorder_index_result_columns(
+    columns: &[IndexResultColumn],
+    indices: &UInt32Array,
+) -> ILResult<Vec<IndexResultColumn>> {
+    columns
+        .iter()
+        .map(|column| {
+            let values = arrow::compute::take(column.values.as_ref(), indices, None)?;
+            Ok(IndexResultColumn {
+                field: column.field.clone(),
+                values,
+            })
+        })
+        .collect()
+}
+
+pub fn empty_index_result_columns(fields: &[FieldRef]) -> Vec<IndexResultColumn> {
+    fields
+        .iter()
+        .map(|field| IndexResultColumn {
+            field: field.clone(),
+            values: new_null_array(field.data_type(), 0),
+        })
+        .collect()
+}
+
+pub fn concat_index_result_columns(
+    column_groups: &[Vec<IndexResultColumn>],
+    fields: &[FieldRef],
+) -> ILResult<Vec<IndexResultColumn>> {
+    if fields.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if column_groups.is_empty() {
+        return Ok(empty_index_result_columns(fields));
+    }
+
+    let mut output = Vec::with_capacity(fields.len());
+    for (idx, field) in fields.iter().enumerate() {
+        let arrays = column_groups
+            .iter()
+            .map(|group| {
+                let column = group.get(idx).ok_or_else(|| {
+                    ILError::internal(format!(
+                        "Dynamic column group missing column {}",
+                        field.name()
+                    ))
+                })?;
+                if column.field.as_ref() != field.as_ref() {
+                    return Err(ILError::internal(format!(
+                        "Dynamic column field mismatch: expected {:?}, got {:?}",
+                        field, column.field
+                    )));
+                }
+                Ok(column.values.as_ref())
+            })
+            .collect::<ILResult<Vec<_>>>()?;
+        let values = arrow::compute::concat(arrays.as_slice())?;
+        output.push(IndexResultColumn {
+            field: field.clone(),
+            values,
+        });
+    }
+    Ok(output)
+}
+
+pub fn validate_index_result_columns(
+    columns: &[IndexResultColumn],
+    fields: &[FieldRef],
+    expected_len: usize,
+) -> ILResult<()> {
+    if columns.len() != fields.len() {
+        return Err(ILError::internal(format!(
+            "Dynamic column count mismatch: expected {}, got {}",
+            fields.len(),
+            columns.len()
+        )));
+    }
+
+    for (column, field) in columns.iter().zip(fields.iter()) {
+        if column.field.as_ref() != field.as_ref() {
+            return Err(ILError::internal(format!(
+                "Dynamic column field mismatch: expected {:?}, got {:?}",
+                field, column.field
+            )));
+        }
+        if column.values.len() != expected_len {
+            return Err(ILError::internal(format!(
+                "Dynamic column {} length {} does not match expected row count {}",
+                column.field.name(),
+                column.values.len(),
+                expected_len
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn project_schema_and_append_fields(
+    schema: &Schema,
+    projection: Option<&Vec<usize>>,
+    extra_fields: &[FieldRef],
+) -> ILResult<Schema> {
+    let mut fields = project_schema(schema, projection)?
+        .fields()
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    fields.extend(extra_fields.iter().cloned());
+    Ok(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+pub fn gather_index_result_columns(
+    row_ids: &[Uuid],
+    lookups: &[DynamicColumnLookup],
+) -> ILResult<Vec<IndexResultColumn>> {
+    if lookups.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    lookups
+        .iter()
+        .map(|lookup| {
+            let indices = row_ids
+                .iter()
+                .map(|row_id| {
+                    lookup.row_id_to_index.get(row_id).copied().ok_or_else(|| {
+                        ILError::internal(format!(
+                            "Dynamic column {} lookup missing row id {row_id}",
+                            lookup.field.name()
+                        ))
+                    })
+                })
+                .collect::<ILResult<Vec<_>>>()?;
+            let indices = UInt32Array::from(indices);
+            let values = arrow::compute::take(lookup.values.as_ref(), &indices, None)?;
+            Ok(IndexResultColumn {
+                field: lookup.field.clone(),
+                values,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicColumnLookup {
+    pub field: FieldRef,
+    pub row_id_to_index: HashMap<Uuid, u32>,
+    pub values: ArrayRef,
+}
+
+impl DynamicColumnLookup {
+    pub fn try_new(field: FieldRef, row_ids: &[Uuid], values: ArrayRef) -> ILResult<Self> {
+        if row_ids.len() != values.len() {
+            return Err(ILError::internal(format!(
+                "Dynamic column {} length {} does not match row id count {}",
+                field.name(),
+                values.len(),
+                row_ids.len()
+            )));
+        }
+
+        let mut row_id_to_index = HashMap::with_capacity(row_ids.len());
+        for (idx, row_id) in row_ids.iter().enumerate() {
+            row_id_to_index.insert(*row_id, idx as u32);
+        }
+
+        Ok(Self {
+            field,
+            row_id_to_index,
+            values,
+        })
+    }
+}
+
+pub fn extract_dynamic_fields(columns: &[IndexResultColumn]) -> Vec<FieldRef> {
+    columns.iter().map(|column| column.field.clone()).collect()
 }
 
 pub fn correct_batch_schema(

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -42,9 +42,8 @@ pub async fn full_table_scan(table: &Table) -> ILResult<String> {
 }
 
 pub async fn table_scan(table: &Table, scan: TableScan) -> ILResult<String> {
-    let batch_schema = scan.output_schema(&table.output_schema)?;
-    let batch_schema = Arc::new(schema_without_row_id(&batch_schema));
-
+    let base_schema = scan.output_schema(&table.output_schema)?;
+    let fallback_schema = Arc::new(schema_without_row_id(base_schema.as_ref()));
     let stream = table.scan(scan).await?;
     let batches = stream.try_collect::<Vec<_>>().await?;
     let mut sorted_batches = if batches.is_empty() {
@@ -60,17 +59,17 @@ pub async fn table_scan(table: &Table, scan: TableScan) -> ILResult<String> {
         batch.remove_column(idx);
     }
 
+    let batch_schema = sorted_batches
+        .first()
+        .map(|batch| batch.schema())
+        .unwrap_or(fallback_schema);
     let table_str = pretty_format_batches_with_schema(batch_schema, &sorted_batches)?.to_string();
     Ok(table_str)
 }
 
 pub async fn table_search(table: &Table, search: TableSearch) -> ILResult<String> {
-    let batch_schema = Arc::new(project_schema(
-        &table.output_schema,
-        search.projection.as_ref(),
-    )?);
-    let batch_schema = Arc::new(schema_without_row_id(&batch_schema));
-
+    let base_schema = project_schema(&table.output_schema, search.projection.as_ref())?;
+    let fallback_schema = Arc::new(schema_without_row_id(&base_schema));
     let stream = table.search(search).await?;
     let mut batches = stream.try_collect::<Vec<_>>().await?;
 
@@ -81,6 +80,11 @@ pub async fn table_search(table: &Table, search: TableSearch) -> ILResult<String
         batch.remove_column(idx);
     }
 
+    let batch_schema = if let Some(batch) = batches.first() {
+        batch.schema()
+    } else {
+        fallback_schema
+    };
     let table_str = pretty_format_batches_with_schema(batch_schema, &batches)?.to_string();
     Ok(table_str)
 }

--- a/integration-tests/tests/index_bm25.rs
+++ b/integration-tests/tests/index_bm25.rs
@@ -1,8 +1,9 @@
-use arrow::array::StringArray;
+use arrow::array::{Float64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
+use futures::TryStreamExt;
 use indexlake::Client;
 use indexlake::catalog::Catalog;
-use indexlake::index::IndexKind;
+use indexlake::index::{IndexColumnRequest, IndexKind};
 use indexlake::storage::Storage;
 use indexlake::table::{TableConfig, TableCreation, TableInsertion, TableSearch};
 use indexlake_integration_tests::{
@@ -103,6 +104,7 @@ async fn create_bm25_index(
             limit: Some(2),
         }),
         projection: None,
+        index_columns: vec![],
     };
     let table_str = table_search(&table, search).await?;
     println!("{}", table_str);
@@ -122,6 +124,7 @@ async fn create_bm25_index(
             limit: Some(2),
         }),
         projection: None,
+        index_columns: vec![],
     };
     let table_str = table_search(&table, search).await?;
     println!("{}", table_str);
@@ -134,6 +137,34 @@ async fn create_bm25_index(
 | title5 | 小明硕士毕业于中国科学院计算所，后在日本京都大学深造。                               |
 +--------+--------------------------------------------------------------------------------------+"#,
     );
+
+    let search = TableSearch {
+        query: Arc::new(BM25SearchQuery {
+            query: "pink".to_string(),
+            limit: Some(2),
+        }),
+        projection: None,
+        index_columns: vec![IndexColumnRequest {
+            index_name: None,
+            name: "score".to_string(),
+            alias: None,
+        }],
+    };
+    let batches = table.search(search).await?.try_collect::<Vec<_>>().await?;
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(
+        batch.schema().field(batch.num_columns() - 1).name(),
+        "score"
+    );
+    let scores = batch
+        .column(batch.num_columns() - 1)
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .expect("score should be Float64Array");
+    assert_eq!(scores.len(), 2);
+    assert!(scores.value(0).is_finite());
+    assert!(scores.value(1).is_finite());
 
     Ok(())
 }

--- a/integration-tests/tests/index_btree.rs
+++ b/integration-tests/tests/index_btree.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use indexlake::Client;
 use indexlake::catalog::{Catalog, Scalar};
 use indexlake::expr::{col, lit};
-use indexlake::index::IndexKind;
+use indexlake::index::{IndexColumnRequest, IndexKind};
 use indexlake::storage::{DataFileFormat, Storage};
 use indexlake::table::{IndexCreation, TableScan};
 use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
@@ -64,6 +64,25 @@ async fn create_btree_index_integer(
 | 3  | 75      |
 | 6  | 75      |
 +----+---------+"#
+    );
+
+    let scan = TableScan::default()
+        .with_filters(vec![col("integer").eq(lit(Scalar::Int32(Some(75))))])
+        .with_index_columns(vec![IndexColumnRequest {
+            index_name: Some("btree_index".to_string()),
+            name: "index_key".to_string(),
+            alias: Some("matched_value".to_string()),
+        }]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("point query result with dynamic column:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+---------+---------------+
+| id | integer | matched_value |
++----+---------+---------------+
+| 3  | 75      | 75            |
+| 6  | 75      | 75            |
++----+---------+---------------+"#
     );
 
     // test range query

--- a/integration-tests/tests/index_hnsw.rs
+++ b/integration-tests/tests/index_hnsw.rs
@@ -54,6 +54,7 @@ async fn create_hnsw_index(
             limit: 2,
         }),
         projection: None,
+        index_columns: vec![],
     };
 
     let table = client.load_table(&namespace_name, &table_name).await?;


### PR DESCRIPTION
## Summary
- add shared index result-column request/response plumbing for scan and search
- expose BM25 search score and BTree scan index_key as dynamic result columns
- append dynamic columns in table scan/search output paths and add integration coverage

## Testing
- cargo check
- cargo test -p indexlake-integration-tests --test index_bm25 create_bm25_index::case_1 -- --nocapture
- cargo test -p indexlake-integration-tests --test index_btree create_btree_index_integer::case_1 -- --nocapture