### PR TITLE
ci(benchmarks): add rabitq benchmark support

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,11 +44,12 @@ jobs:
             const prNumber = isDispatch ? Number(core.getInput('pr_number')) : context.payload.issue.number;
 
             const allowed = {
-              all: ["indexlake", "indexlake_btree", "indexlake_bm25", "indexlake_hnsw", "indexlake_rstar"],
+              all: ["indexlake", "indexlake_btree", "indexlake_bm25", "indexlake_hnsw", "indexlake_rabitq", "indexlake_rstar"],
               indexlake: ["indexlake"],
               btree: ["indexlake_btree"],
               bm25: ["indexlake_bm25"],
               hnsw: ["indexlake_hnsw"],
+              rabitq: ["indexlake_rabitq"],
               rstar: ["indexlake_rstar"],
             };
 


### PR DESCRIPTION
Add RaBitQ benchmark support to the benchmarks workflow.

Changes:
- Add \indexlake_rabitq\ to the \ll\ benchmark list
- Add \abitq\ as a valid benchmark target

This allows running \/bench rabitq\ or including rabitq in the default \/bench\ command.