### PR TITLE
docs(readme): add RaBitQ to index list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **IndexLake** is an experimental table format with extensible index and inline table support.
 
-- **Extensible Index System**: Pluggable index types (BM25, B-Tree, HNSW, R*-tree)
+- **Extensible Index System**: Pluggable index types (BM25, B-Tree, HNSW, RaBitQ, R*-tree)
 - **Inline Tables**: Store small datasets directly within the catalog
 - **ACID Transaction**: Support transaction through sql catalog
 - **Flexible Catalog**: PostgreSQL and SQLite catalog support


### PR DESCRIPTION
Add RaBitQ (Randomized binary and quantization index) to the README index list.

This index was recently added in PR #92 but was missing from the documentation.