### PR TITLE
ci(benchmark): add indexlake_vs_datafusion to benchmark CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,13 +44,14 @@ jobs:
             const prNumber = isDispatch ? Number(core.getInput('pr_number')) : context.payload.issue.number;
 
             const allowed = {
-              all: ["indexlake", "indexlake_btree", "indexlake_bm25", "indexlake_hnsw", "indexlake_rabitq", "indexlake_rstar"],
+              all: ["indexlake", "indexlake_btree", "indexlake_bm25", "indexlake_hnsw", "indexlake_rabitq", "indexlake_rstar", "indexlake_vs_datafusion"],
               indexlake: ["indexlake"],
               indexlake_btree: ["indexlake_btree"],
               indexlake_bm25: ["indexlake_bm25"],
               indexlake_hnsw: ["indexlake_hnsw"],
               indexlake_rabitq: ["indexlake_rabitq"],
               indexlake_rstar: ["indexlake_rstar"],
+              indexlake_vs_datafusion: ["indexlake_vs_datafusion"],
             };
 
             let benchKey = "all";


### PR DESCRIPTION
This PR adds support for the new `indexlake_vs_datafusion` benchmark in the CI workflow.

### Changes
- Added `indexlake_vs_datafusion` to the `all` benchmark list
- Added `indexlake_vs_datafusion` as a standalone benchmark option

### Usage
After this PR is merged, you can run the new benchmark via:
- `/bench indexlake_vs_datafusion`
- `/benchmark indexlake_vs_datafusion`
- `/bench` (runs all benchmarks including the new one)

### Files Modified
- `.github/workflows/benchmarks.yml`
