### PR TITLE
feat(search): fix column ordering when projection excludes _row_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea
 integration-tests/tmp
+docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -703,6 +704,16 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -932,6 +943,7 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -953,6 +965,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
+ "parquet",
  "rand 0.9.2",
  "regex",
  "sqlparser",
@@ -2087,6 +2100,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2314,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2302,6 +2335,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2572,6 +2606,7 @@ name = "indexlake-benchmarks"
 version = "0.4.0"
 dependencies = [
  "arrow",
+ "datafusion",
  "futures",
  "geo",
  "geozero",
@@ -2582,8 +2617,11 @@ dependencies = [
  "indexlake-index-rabitq",
  "indexlake-index-rstar",
  "indexlake-integration-tests",
+ "object_store",
+ "opendal",
  "rand 0.10.0",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -3240,14 +3278,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
  "http",
+ "http-body-util",
  "humantime",
+ "hyper",
  "itertools 0.14.0",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.2",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3297,6 +3347,12 @@ dependencies = [
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -3944,6 +4000,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3956,6 +4013,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4139,6 +4197,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4181,6 +4251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,6 +4270,29 @@ name = "scroll"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -8,8 +8,8 @@ use futures::TryStreamExt;
 use uuid::Uuid;
 
 use crate::catalog::{
-    CatalogHelper, CatalogSchema, DataFileRecord, IndexFileRecord, InlineIndexRecord, Row,
-    rows_to_record_batch,
+    CatalogHelper, CatalogSchema, DataFileRecord, INTERNAL_ROW_ID_FIELD_NAME, IndexFileRecord,
+    InlineIndexRecord, Row, rows_to_record_batch,
 };
 use crate::expr::row_ids_in_list_expr;
 use crate::index::{DynamicColumn, IndexDefinitionRef, IndexKind, SearchIndexEntries, SearchQuery};
@@ -194,6 +194,8 @@ pub(crate) async fn process_search(
     let dynamic_columns =
         gather_dynamic_columns_from_batch(&sorted_batch, &merged_entries.dynamic_lookups)?;
     let final_batch = append_dynamic_columns_to_record_batch(&sorted_batch, &dynamic_columns)?;
+    // Remove internal _row_id column from final output
+    let final_batch = remove_row_id_column(&final_batch)?;
 
     Ok(Box::pin(futures::stream::iter(vec![Ok(final_batch)])))
 }
@@ -443,6 +445,34 @@ fn append_dynamic_columns_to_record_batch(
     Ok(RecordBatch::try_new(schema, arrays)?)
 }
 
+fn remove_row_id_column(batch: &RecordBatch) -> ILResult<RecordBatch> {
+    let schema = batch.schema();
+    let row_id_idx = schema.index_of(INTERNAL_ROW_ID_FIELD_NAME)?;
+    let mut fields = Vec::with_capacity(batch.num_columns() - 1);
+    let mut columns = Vec::with_capacity(batch.num_columns() - 1);
+    for (i, field) in schema.fields().iter().enumerate() {
+        if i != row_id_idx {
+            fields.push(field.clone());
+            columns.push(batch.column(i).clone());
+        }
+    }
+    let new_schema = Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()));
+    RecordBatch::try_new(new_schema, columns)
+        .map_err(|e| ILError::internal(format!("Failed to remove row id column: {}", e)))
+}
+
+/// Reorder batch columns to match the order of the target schema
+fn reorder_batch_to_schema(batch: &RecordBatch, target_schema: &Schema) -> ILResult<RecordBatch> {
+    let batch_schema = batch.schema();
+    let mut columns = Vec::with_capacity(target_schema.fields.len());
+    for target_field in target_schema.fields.iter() {
+        let idx = batch_schema.index_of(target_field.name())?;
+        columns.push(batch.column(idx).clone());
+    }
+    RecordBatch::try_new(Arc::new(target_schema.clone()), columns)
+        .map_err(|e| ILError::internal(format!("Failed to reorder batch: {}", e)))
+}
+
 async fn read_rows(
     catalog_helper: &CatalogHelper,
     table: &Table,
@@ -468,9 +498,29 @@ async fn read_rows(
         }
     }
 
+    // Build internal projection that always includes _row_id for internal processing
+    // (sort_batches and gather_dynamic_columns_from_batch need _row_id)
+    // _row_id must be at position 0, so we PREPEND it to the user projection
+    let row_id_idx = table
+        .table_schema
+        .arrow_schema
+        .index_of(INTERNAL_ROW_ID_FIELD_NAME)?;
+    let internal_projection = if let Some(ref user_proj) = projection {
+        if user_proj.contains(&row_id_idx) {
+            projection.clone()
+        } else {
+            let mut proj = vec![row_id_idx];
+            proj.extend(user_proj.iter());
+            Some(proj)
+        }
+    } else {
+        None // No projection means all columns including _row_id
+    };
+
+    // Use internal_projection (which includes _row_id) for reading data
     let projected_schema = Arc::new(project_schema(
         &table.table_schema.arrow_schema,
-        projection.as_ref(),
+        internal_projection.as_ref(),
     )?);
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&projected_schema)?);
 
@@ -498,7 +548,7 @@ async fn read_rows(
         .into_iter()
         .map(|(data_file_id, row_ids)| {
             let table = table.clone();
-            let projection = projection.clone();
+            let internal_projection = internal_projection.clone();
             let data_file_records = data_file_records.to_vec();
 
             tokio::spawn(async move {
@@ -515,7 +565,7 @@ async fn read_rows(
                     table.storage.as_ref(),
                     &table.table_schema,
                     data_file_record,
-                    projection,
+                    internal_projection,
                     vec![row_ids_in_list_expr(row_ids)],
                     1024,
                 )
@@ -551,7 +601,9 @@ fn sort_batches(
 ) -> ILResult<RecordBatch> {
     let mut batch = inline_batch;
     for data_file_batch in data_file_batches {
-        batch = arrow::compute::concat_batches(&batch.schema(), [&batch, &data_file_batch])?;
+        // Ensure data_file_batch has the same column order as batch before concatenating
+        let reordered = reorder_batch_to_schema(&data_file_batch, batch.schema().as_ref())?;
+        batch = arrow::compute::concat_batches(&batch.schema(), [&batch, &reordered])?;
     }
 
     let mut scores = Vec::new();

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -176,11 +176,35 @@ pub(crate) async fn process_search(
         search.query.limit(),
     )?;
 
+    let row_id_idx = table
+        .table_schema
+        .arrow_schema
+        .index_of(INTERNAL_ROW_ID_FIELD_NAME)?;
+
+    // Determine if user explicitly requested _row_id in their projection
+    let user_wants_row_id = search
+        .projection
+        .as_ref()
+        .map(|p| p.contains(&row_id_idx))
+        .unwrap_or(true); // None means all columns, which includes _row_id
+
+    // Build internal projection that always includes _row_id for internal processing
+    // (sort_batches and gather_dynamic_columns_from_batch need _row_id at position 0)
+    let internal_projection = if user_wants_row_id {
+        search.projection.clone()
+    } else {
+        search.projection.as_ref().map(|p| {
+            let mut proj = vec![row_id_idx];
+            proj.extend(p.iter());
+            proj
+        })
+    };
+
     let (inline_batch, data_file_batches) = read_rows(
         &catalog_helper,
         table,
         &merged_entries.row_score_locations,
-        search.projection.clone(),
+        internal_projection,
         &data_file_records,
     )
     .await?;
@@ -194,8 +218,13 @@ pub(crate) async fn process_search(
     let dynamic_columns =
         gather_dynamic_columns_from_batch(&sorted_batch, &merged_entries.dynamic_lookups)?;
     let final_batch = append_dynamic_columns_to_record_batch(&sorted_batch, &dynamic_columns)?;
-    // Remove internal _row_id column from final output
-    let final_batch = remove_row_id_column(&final_batch)?;
+
+    // Remove internal _row_id column from final output only if user didn't request it
+    let final_batch = if user_wants_row_id {
+        final_batch
+    } else {
+        remove_row_id_column(&final_batch)?
+    };
 
     Ok(Box::pin(futures::stream::iter(vec![Ok(final_batch)])))
 }
@@ -498,29 +527,10 @@ async fn read_rows(
         }
     }
 
-    // Build internal projection that always includes _row_id for internal processing
-    // (sort_batches and gather_dynamic_columns_from_batch need _row_id)
-    // _row_id must be at position 0, so we PREPEND it to the user projection
-    let row_id_idx = table
-        .table_schema
-        .arrow_schema
-        .index_of(INTERNAL_ROW_ID_FIELD_NAME)?;
-    let internal_projection = if let Some(ref user_proj) = projection {
-        if user_proj.contains(&row_id_idx) {
-            projection.clone()
-        } else {
-            let mut proj = vec![row_id_idx];
-            proj.extend(user_proj.iter());
-            Some(proj)
-        }
-    } else {
-        None // No projection means all columns including _row_id
-    };
-
-    // Use internal_projection (which includes _row_id) for reading data
+    // Use the provided projection directly (caller ensures _row_id is included if needed)
     let projected_schema = Arc::new(project_schema(
         &table.table_schema.arrow_schema,
-        internal_projection.as_ref(),
+        projection.as_ref(),
     )?);
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&projected_schema)?);
 
@@ -548,7 +558,7 @@ async fn read_rows(
         .into_iter()
         .map(|(data_file_id, row_ids)| {
             let table = table.clone();
-            let internal_projection = internal_projection.clone();
+            let projection = projection.clone();
             let data_file_records = data_file_records.to_vec();
 
             tokio::spawn(async move {
@@ -565,7 +575,7 @@ async fn read_rows(
                     table.storage.as_ref(),
                     &table.table_schema,
                     data_file_record,
-                    internal_projection,
+                    projection,
                     vec![row_ids_in_list_expr(row_ids)],
                     1024,
                 )
@@ -632,4 +642,220 @@ fn sort_batches(
     let batch = arrow::compute::take_record_batch(&batch, &indices)?;
 
     Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{StringArray, UInt64Array};
+    use arrow::datatypes::{DataType, Field};
+
+    fn create_test_batch_with_row_id() -> RecordBatch {
+        let schema = Schema::new(vec![
+            Field::new(INTERNAL_ROW_ID_FIELD_NAME, DataType::UInt64, false),
+            Field::new("title", DataType::Utf8, false),
+            Field::new("score", DataType::Float64, false),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(UInt64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn create_test_batch_without_row_id() -> RecordBatch {
+        let schema = Schema::new(vec![
+            Field::new("title", DataType::Utf8, false),
+            Field::new("score", DataType::Float64, false),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_remove_row_id_column() {
+        let batch = create_test_batch_with_row_id();
+        let result = remove_row_id_column(&batch).unwrap();
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(
+            result
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect::<Vec<_>>(),
+            vec!["title", "score"]
+        );
+        assert_eq!(result.num_rows(), 3);
+    }
+
+    #[test]
+    fn test_remove_row_id_column_preserves_data() {
+        let batch = create_test_batch_with_row_id();
+        let result = remove_row_id_column(&batch).unwrap();
+
+        let title_col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(title_col.value(0), "a");
+        assert_eq!(title_col.value(1), "b");
+        assert_eq!(title_col.value(2), "c");
+
+        let score_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        assert_eq!(score_col.value(0), 1.0);
+        assert_eq!(score_col.value(1), 2.0);
+        assert_eq!(score_col.value(2), 3.0);
+    }
+
+    #[test]
+    fn test_reorder_batch_to_schema() {
+        let batch = create_test_batch_with_row_id();
+        let target_schema = Schema::new(vec![
+            Field::new("score", DataType::Float64, false),
+            Field::new("title", DataType::Utf8, false),
+            Field::new(INTERNAL_ROW_ID_FIELD_NAME, DataType::UInt64, false),
+        ]);
+
+        let result = reorder_batch_to_schema(&batch, &target_schema).unwrap();
+
+        assert_eq!(result.num_columns(), 3);
+        // Verify order matches target schema
+        assert_eq!(result.schema().field(0).name(), "score");
+        assert_eq!(result.schema().field(1).name(), "title");
+        assert_eq!(result.schema().field(2).name(), INTERNAL_ROW_ID_FIELD_NAME);
+    }
+
+    #[test]
+    fn test_reorder_batch_preserves_data() {
+        let batch = create_test_batch_with_row_id();
+        let target_schema = Schema::new(vec![
+            Field::new("score", DataType::Float64, false),
+            Field::new("title", DataType::Utf8, false),
+            Field::new(INTERNAL_ROW_ID_FIELD_NAME, DataType::UInt64, false),
+        ]);
+
+        let result = reorder_batch_to_schema(&batch, &target_schema).unwrap();
+
+        // Check score column (was at index 2, now at index 0)
+        let score_col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        assert_eq!(score_col.value(0), 1.0);
+    }
+
+    #[test]
+    fn test_user_wants_row_id_logic() {
+        // Test case: projection excludes _row_id (index 0 in full schema with row_id)
+        let projection = Some(vec![1]); // Only "title" column
+        let row_id_idx = 0;
+
+        let user_wants_row_id = projection
+            .as_ref()
+            .map(|p| p.contains(&row_id_idx))
+            .unwrap_or(true);
+        assert!(!user_wants_row_id);
+
+        // Test case: projection includes _row_id
+        let projection_with_row_id = Some(vec![0, 1]); // _row_id and title
+        let user_wants_row_id = projection_with_row_id
+            .as_ref()
+            .map(|p| p.contains(&row_id_idx))
+            .unwrap_or(true);
+        assert!(user_wants_row_id);
+
+        // Test case: None projection means all columns
+        let projection_none: Option<Vec<usize>> = None;
+        let user_wants_row_id = projection_none
+            .as_ref()
+            .map(|p| p.contains(&row_id_idx))
+            .unwrap_or(true);
+        assert!(user_wants_row_id);
+    }
+
+    #[test]
+    fn test_internal_projection_includes_row_id_when_user_excludes() {
+        let row_id_idx = 0;
+        let user_projection = Some(vec![1]); // Only "title" (index 1 in full schema)
+
+        // Simulating the logic in process_search
+        let user_wants_row_id = user_projection
+            .as_ref()
+            .map(|p| p.contains(&row_id_idx))
+            .unwrap_or(true);
+
+        let internal_projection = if user_wants_row_id {
+            user_projection.clone()
+        } else {
+            user_projection.as_ref().map(|p| {
+                let mut proj = vec![row_id_idx];
+                proj.extend(p.iter());
+                proj
+            })
+        };
+
+        // Internal projection should include row_id at position 0
+        let internal_proj = internal_projection.unwrap();
+        assert_eq!(internal_proj[0], row_id_idx);
+        assert_eq!(internal_proj[1], 1); // title is now at position 1
+        assert_eq!(internal_proj.len(), 2);
+    }
+
+    #[test]
+    fn test_internal_projection_preserves_user_row_id_request() {
+        let row_id_idx = 0;
+        let user_projection = Some(vec![0, 1]); // Both _row_id and title
+
+        let user_wants_row_id = user_projection
+            .as_ref()
+            .map(|p| p.contains(&row_id_idx))
+            .unwrap_or(true);
+
+        let internal_projection = if user_wants_row_id {
+            user_projection.clone()
+        } else {
+            user_projection.as_ref().map(|p| {
+                let mut proj = vec![row_id_idx];
+                proj.extend(p.iter());
+                proj
+            })
+        };
+
+        // Should be unchanged since user already included row_id
+        let internal_proj = internal_projection.unwrap();
+        assert_eq!(internal_proj, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_batch_without_row_id_to_schema() {
+        // Test reordering a batch that doesn't have row_id
+        let batch = create_test_batch_without_row_id();
+        let target_schema = Schema::new(vec![
+            Field::new("score", DataType::Float64, false),
+            Field::new("title", DataType::Utf8, false),
+        ]);
+
+        let result = reorder_batch_to_schema(&batch, &target_schema).unwrap();
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.schema().field(0).name(), "score");
+        assert_eq!(result.schema().field(1).name(), "title");
+    }
 }

--- a/integration-tests/tests/index_bm25.rs
+++ b/integration-tests/tests/index_bm25.rs
@@ -167,3 +167,122 @@ async fn create_bm25_index(
 
     Ok(())
 }
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn search_with_projection_excluding_row_id(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(BM25IndexKind));
+
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::Utf8, false),
+        Field::new("content", DataType::Utf8, false),
+    ]));
+    let table_config = TableConfig {
+        inline_row_count_limit: 3,
+        parquet_row_group_size: 2,
+        preferred_data_file_format: format,
+    };
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: table_config,
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+
+    let index_creation = IndexCreation {
+        name: "bm25_index".to_string(),
+        kind: BM25IndexKind.kind().to_string(),
+        key_columns: vec!["content".to_string()],
+        params: Arc::new(BM25IndexParams { avgdl: 256. }),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    let table = client.load_table(&namespace_name, &table_name).await?;
+    table.create_index(index_creation.clone()).await?;
+
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Insert 7 rows - first 3 go to inline, remaining 4 go to data files
+    let record_batch = RecordBatch::try_new(
+        table_schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![
+                "title1", "title2", "title3", "title4", "title5", "title6", "title7",
+            ])),
+            Arc::new(StringArray::from(vec![
+                "The sky blushed pink as the sun dipped below the horizon.",
+                "She found a forgotten letter tucked inside an old book.",
+                "Apples, oranges, pink grapefruits, and more pink grapefruits.",
+                "A single drop of rain fell, followed by a thousand more.",
+                "小明硕士毕业于中国科学院计算所，后在日本京都大学深造。",
+                "张华考上了北京大学；李萍进了中国人民大学；我在百货公司当售货员：我们都有光明的前途。",
+                "今天天气真不错，我去了公园，看到了很多花，很漂亮。",
+            ])),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![record_batch]))
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    // This search uses projection [1] (title only) without _row_id, combined with dynamic_fields
+    // This should trigger the bug: sort_batches expects _row_id at column 0 but gets title instead
+    let search = TableSearch {
+        query: Arc::new(BM25SearchQuery {
+            query: "pink".to_string(),
+            limit: Some(2),
+        }),
+        projection: Some(vec![1]), // Only title column, excluding _row_id
+        dynamic_fields: vec!["score".to_string()],
+    };
+
+    // This search uses projection [1] (title only) without _row_id, combined with dynamic_fields
+    // With the fix, this should now work correctly:
+    // 1. read_rows internally adds _row_id to the projection
+    // 2. sort_batches and gather_dynamic_columns work with _row_id
+    // 3. Final output removes _row_id, returning only title + score
+    let result = table_search(&table, search).await;
+    let table_str = result?;
+
+    // Verify the output contains title and score but not _row_id
+    assert!(
+        table_str.contains("title"),
+        "Output should contain title column"
+    );
+    assert!(
+        table_str.contains("score"),
+        "Output should contain score column"
+    );
+    assert!(
+        !table_str.contains("_row_id"),
+        "Output should NOT contain _row_id column"
+    );
+    assert!(
+        !table_str.contains("_indexlake_row_id"),
+        "Output should NOT contain _indexlake_row_id column"
+    );
+
+    println!("Search succeeded: {}", table_str);
+
+    Ok(())
+}


### PR DESCRIPTION
  When a user projection excludes the internal _row_id column, internal
  processing (sort_batches, gather_dynamic_columns) still needs _row_id
  but was receiving the wrong column order. This commit:

  - Adds remove_row_id_column() to strip _row_id from final output
  - Adds reorder_batch_to_schema() to ensure consistent column ordering before concatenating batches from inline and data files
  - Modifies read_rows() to always prepend _row_id to internal projection even when user excludes it
  - Adds integration test for search with projection [1] (title only)