### PR TITLE
refactor: remove as_any from index traits

### DIFF
--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::Float64Array;
@@ -19,10 +18,6 @@ pub struct BM25SearchQuery {
 }
 
 impl SearchQuery for BM25SearchQuery {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn index_kind(&self) -> &str {
         "bm25"
     }
@@ -47,7 +42,6 @@ impl Index for BM25Index {
         dynamic_fields: &[String],
     ) -> ILResult<SearchIndexEntries> {
         let query = query
-            .as_any()
             .downcast_ref::<BM25SearchQuery>()
             .ok_or(ILError::index("Invalid query type"))?;
         let query_embedding = self.embedder.embed(&query.query);

--- a/indexes/bm25/src/kind.rs
+++ b/indexes/bm25/src/kind.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, FieldRef};
@@ -51,7 +50,7 @@ impl IndexKind for BM25IndexKind {
     }
 
     fn supports_search(&self, _: &IndexDefinition, query: &dyn SearchQuery) -> ILResult<bool> {
-        if query.as_any().downcast_ref::<BM25SearchQuery>().is_some() {
+        if query.downcast_ref::<BM25SearchQuery>().is_some() {
             Ok(true)
         } else {
             Ok(false)
@@ -77,10 +76,6 @@ pub struct BM25IndexParams {
 }
 
 impl IndexParams for BM25IndexParams {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn encode(&self) -> ILResult<String> {
         serde_json::to_string(self).map_err(|e| ILError::index(e.to_string()))
     }

--- a/indexes/btree/src/kind.rs
+++ b/indexes/btree/src/kind.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, FieldRef};
@@ -105,10 +104,6 @@ impl IndexKind for BTreeIndexKind {
 pub struct BTreeIndexParams {}
 
 impl IndexParams for BTreeIndexParams {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn encode(&self) -> ILResult<String> {
         serde_json::to_string(self).map_err(|e| ILError::index(e.to_string()))
     }

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::Float64Array;
@@ -20,10 +19,6 @@ pub struct HnswSearchQuery {
 }
 
 impl SearchQuery for HnswSearchQuery {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn index_kind(&self) -> &str {
         "hnsw"
     }
@@ -57,14 +52,11 @@ impl Index for HnswIndex {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
     ) -> ILResult<SearchIndexEntries> {
-        let query = query
-            .as_any()
-            .downcast_ref::<HnswSearchQuery>()
-            .ok_or_else(|| {
-                ILError::index(format!(
-                    "Hnsw index does not support search query: {query:?}"
-                ))
-            })?;
+        let query = query.downcast_ref::<HnswSearchQuery>().ok_or_else(|| {
+            ILError::index(format!(
+                "Hnsw index does not support search query: {query:?}"
+            ))
+        })?;
 
         let limit = std::cmp::min(query.limit, self.hnsw.len());
 

--- a/indexes/hnsw/src/kind.rs
+++ b/indexes/hnsw/src/kind.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, FieldRef};
@@ -61,7 +60,7 @@ impl IndexKind for HnswIndexKind {
         _index_def: &IndexDefinition,
         query: &dyn SearchQuery,
     ) -> ILResult<bool> {
-        let Some(_query) = query.as_any().downcast_ref::<HnswSearchQuery>() else {
+        let Some(_query) = query.downcast_ref::<HnswSearchQuery>() else {
             return Ok(false);
         };
         Ok(true)
@@ -90,10 +89,6 @@ pub struct HnswIndexParams {
 }
 
 impl IndexParams for HnswIndexParams {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn encode(&self) -> ILResult<String> {
         let json = serde_json::to_string(self)
             .map_err(|e| ILError::index(format!("Failed to encode HnswIndexParams: {e}")))?;

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::Float64Array;
@@ -24,10 +23,6 @@ impl RabitqSearchQuery {
 }
 
 impl SearchQuery for RabitqSearchQuery {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn index_kind(&self) -> &str {
         "rabitq"
     }
@@ -58,14 +53,11 @@ impl Index for RabitqIndex {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
     ) -> ILResult<SearchIndexEntries> {
-        let query = query
-            .as_any()
-            .downcast_ref::<RabitqSearchQuery>()
-            .ok_or_else(|| {
-                ILError::index(format!(
-                    "RaBitQ index does not support search query: {query:?}"
-                ))
-            })?;
+        let query = query.downcast_ref::<RabitqSearchQuery>().ok_or_else(|| {
+            ILError::index(format!(
+                "RaBitQ index does not support search query: {query:?}"
+            ))
+        })?;
 
         let score_higher_is_better = matches!(self.metric, RabitqMetric::InnerProduct);
 

--- a/indexes/rabitq/src/kind.rs
+++ b/indexes/rabitq/src/kind.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, FieldRef};
@@ -31,10 +30,6 @@ fn default_total_bits() -> usize {
 }
 
 impl IndexParams for RabitqIndexParams {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn encode(&self) -> ILResult<String> {
         serde_json::to_string(self)
             .map_err(|e| ILError::index(format!("Failed to encode RabitqIndexParams: {e}")))
@@ -92,7 +87,7 @@ impl IndexKind for RabitqIndexKind {
         _index_def: &IndexDefinition,
         query: &dyn SearchQuery,
     ) -> ILResult<bool> {
-        Ok(query.as_any().downcast_ref::<RabitqSearchQuery>().is_some())
+        Ok(query.downcast_ref::<RabitqSearchQuery>().is_some())
     }
 
     fn dynamic_fields(&self, _index_def: &IndexDefinition) -> ILResult<Vec<FieldRef>> {

--- a/indexes/rstar/src/kind.rs
+++ b/indexes/rstar/src/kind.rs
@@ -151,10 +151,6 @@ impl WkbDialect {
 }
 
 impl IndexParams for RStarIndexParams {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn encode(&self) -> ILResult<String> {
         serde_json::to_string(self)
             .map_err(|e| ILError::index(format!("Failed to serialize RStarIndexParams: {e}")))

--- a/indexlake/src/index/definition.rs
+++ b/indexlake/src/index/definition.rs
@@ -43,8 +43,8 @@ impl IndexDefinition {
         Ok(key_fields)
     }
 
-    pub fn downcast_params<T: 'static>(&self) -> ILResult<&T> {
-        self.params.as_any().downcast_ref::<T>().ok_or_else(|| {
+    pub fn downcast_params<T: IndexParams>(&self) -> ILResult<&T> {
+        self.params.downcast_ref::<T>().ok_or_else(|| {
             ILError::internal(format!(
                 "Index params is not {}",
                 std::any::type_name::<T>()

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -95,16 +95,32 @@ pub enum FilterSupport {
     Inexact,
 }
 
-pub trait SearchQuery: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait SearchQuery: Debug + Send + Sync + Any {
     fn index_kind(&self) -> &str;
 
     fn limit(&self) -> Option<usize>;
 }
 
-pub trait IndexParams: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
+impl dyn SearchQuery {
+    pub fn is<T: SearchQuery>(&self) -> bool {
+        (self as &dyn Any).is::<T>()
+    }
 
+    pub fn downcast_ref<T: SearchQuery>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
+    }
+}
+
+pub trait IndexParams: Debug + Send + Sync + Any {
     fn encode(&self) -> ILResult<String>;
+}
+
+impl dyn IndexParams {
+    pub fn is<T: IndexParams>(&self) -> bool {
+        (self as &dyn Any).is::<T>()
+    }
+
+    pub fn downcast_ref<T: IndexParams>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
+    }
 }


### PR DESCRIPTION
﻿## Summary
- remove `as_any` from the `SearchQuery` and `IndexParams` index traits
- add `impl dyn SearchQuery` / `impl dyn IndexParams` helper methods for `is` and `downcast_ref`
- update index query/params downcast call sites without changing Arrow or DataFusion `as_any()` usages

## Motivation
The index trait hierarchy required repeated `as_any` boilerplate in each implementation just to support downcasting. Making `Any` a supertrait keeps the same capability while centralizing downcast helpers on the trait objects themselves.

## Scope
- `indexlake/src/index/mod.rs`
- `indexlake/src/index/definition.rs`
- `indexes/bm25`
- `indexes/btree`
- `indexes/hnsw`
- `indexes/rabitq`
- `indexes/rstar`

## Verification
- `cargo check --workspace`
- `cargo test --workspace`
