### PR TITLE
feat: selective rebuild inline indexes on update (phase 1)

### DIFF
--- a/indexlake/src/index/manager.rs
+++ b/indexlake/src/index/manager.rs
@@ -48,6 +48,35 @@ impl IndexManager {
             .any(|def| def.key_columns.contains(&field_id_str))
     }
 
+    pub(crate) fn index_ids_by_field_ids(&self, field_ids: &[String]) -> Vec<Uuid> {
+        self.indexes
+            .iter()
+            .filter(|index_def| {
+                field_ids
+                    .iter()
+                    .any(|field_id| index_def.key_columns.contains(field_id))
+            })
+            .map(|index_def| index_def.index_id)
+            .collect()
+    }
+
+    pub(crate) fn new_index_builders_by_ids(
+        &self,
+        index_ids: &[Uuid],
+    ) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
+        self.indexes
+            .iter()
+            .filter(|index_def| index_ids.contains(&index_def.index_id))
+            .map(|index_def| {
+                let index_kind = self
+                    .kinds
+                    .get(&index_def.kind)
+                    .expect("Index kind not found");
+                index_kind.builder(index_def)
+            })
+            .collect()
+    }
+
     pub(crate) fn supports_filter(&self, filter: &Expr) -> ILResult<FilterSupport> {
         let mut supports = FilterSupport::Unsupported;
         for index_def in &self.indexes {

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -308,6 +308,33 @@ pub(crate) async fn rebuild_inline_indexes(
     Ok(())
 }
 
+pub(crate) async fn rebuild_inline_indexes_by_ids(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    index_manager: &IndexManager,
+    index_ids: &[Uuid],
+) -> ILResult<()> {
+    let inline_index_records = build_inline_indexes_by_ids(
+        tx_helper,
+        table_id,
+        table_schema,
+        index_manager,
+        index_ids,
+    )
+    .await?;
+
+    // delete old inline index records for specified index_ids only
+    tx_helper.delete_inline_indexes(index_ids).await?;
+
+    // insert inline index records
+    tx_helper
+        .insert_inline_indexes(&inline_index_records)
+        .await?;
+
+    Ok(())
+}
+
 pub(crate) async fn build_all_inline_indexes(
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
@@ -346,6 +373,67 @@ pub(crate) async fn build_all_inline_indexes(
             }
             counter = 0;
             index_builders = index_manager.new_index_builders()?;
+        }
+    }
+    drop(chunk_stream);
+
+    // build inline index records for left rows
+    if counter > 0 {
+        for index_builder in index_builders.iter_mut() {
+            if index_builder.is_empty() {
+                continue;
+            }
+            let mut index_data = Vec::new();
+            index_builder.write_bytes(&mut index_data)?;
+            inline_index_records.push(InlineIndexRecord {
+                index_id: index_builder.index_def().index_id,
+                index_data,
+            });
+        }
+    }
+
+    Ok(inline_index_records)
+}
+
+pub(crate) async fn build_inline_indexes_by_ids(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    index_manager: &IndexManager,
+    index_ids: &[Uuid],
+) -> ILResult<Vec<InlineIndexRecord>> {
+    let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
+    let row_stream = tx_helper
+        .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
+        .await?;
+    let mut chunk_stream = row_stream.chunks(100);
+
+    let mut inline_index_records = Vec::new();
+
+    let mut index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
+    let mut counter = 0;
+    while let Some(row_chunk) = chunk_stream.next().await {
+        let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
+        counter += rows.len();
+        let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
+        for index_builder in index_builders.iter_mut() {
+            index_builder.append(&record_batch)?;
+        }
+
+        if counter >= 1000 {
+            for index_builder in index_builders.iter_mut() {
+                if index_builder.is_empty() {
+                    continue;
+                }
+                let mut index_data = Vec::new();
+                index_builder.write_bytes(&mut index_data)?;
+                inline_index_records.push(InlineIndexRecord {
+                    index_id: index_builder.index_def().index_id,
+                    index_data,
+                });
+            }
+            counter = 0;
+            index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
         }
     }
     drop(chunk_stream);

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -315,14 +315,9 @@ pub(crate) async fn rebuild_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<()> {
-    let inline_index_records = build_inline_indexes_by_ids(
-        tx_helper,
-        table_id,
-        table_schema,
-        index_manager,
-        index_ids,
-    )
-    .await?;
+    let inline_index_records =
+        build_inline_indexes_by_ids(tx_helper, table_id, table_schema, index_manager, index_ids)
+            .await?;
 
     // delete old inline index records for specified index_ids only
     tx_helper.delete_inline_indexes(index_ids).await?;
@@ -341,8 +336,10 @@ pub(crate) async fn build_all_inline_indexes(
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
 ) -> ILResult<Vec<InlineIndexRecord>> {
-    let index_builders = index_manager.new_index_builders()?;
-    build_inline_indexes_with_builders(tx_helper, table_id, table_schema, index_builders).await
+    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders()
+    })
+    .await
 }
 
 pub(crate) async fn build_inline_indexes_by_ids(
@@ -352,15 +349,17 @@ pub(crate) async fn build_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<Vec<InlineIndexRecord>> {
-    let index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
-    build_inline_indexes_with_builders(tx_helper, table_id, table_schema, index_builders).await
+    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders_by_ids(index_ids)
+    })
+    .await
 }
 
-async fn build_inline_indexes_with_builders(
+async fn build_inline_indexes_with_builder_factory(
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
-    mut index_builders: Vec<Box<dyn IndexBuilder>>,
+    mut new_index_builders: impl FnMut() -> ILResult<Vec<Box<dyn IndexBuilder>>>,
 ) -> ILResult<Vec<InlineIndexRecord>> {
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
@@ -369,6 +368,7 @@ async fn build_inline_indexes_with_builders(
     let mut chunk_stream = row_stream.chunks(100);
 
     let mut inline_index_records = Vec::new();
+    let mut index_builders = new_index_builders()?;
     let mut counter = 0;
 
     while let Some(row_chunk) = chunk_stream.next().await {
@@ -382,6 +382,7 @@ async fn build_inline_indexes_with_builders(
         if counter >= 1000 {
             flush_index_builders(&mut index_builders, &mut inline_index_records)?;
             counter = 0;
+            index_builders = new_index_builders()?;
         }
     }
     drop(chunk_stream);

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -341,58 +341,8 @@ pub(crate) async fn build_all_inline_indexes(
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
 ) -> ILResult<Vec<InlineIndexRecord>> {
-    let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
-    let row_stream = tx_helper
-        .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
-        .await?;
-    let mut chunk_stream = row_stream.chunks(100);
-
-    let mut inline_index_records = Vec::new();
-
-    let mut index_builders = index_manager.new_index_builders()?;
-    let mut counter = 0;
-    while let Some(row_chunk) = chunk_stream.next().await {
-        let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
-        counter += rows.len();
-        let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
-        for index_builder in index_builders.iter_mut() {
-            index_builder.append(&record_batch)?;
-        }
-
-        if counter >= 1000 {
-            for index_builder in index_builders.iter_mut() {
-                if index_builder.is_empty() {
-                    continue;
-                }
-                let mut index_data = Vec::new();
-                index_builder.write_bytes(&mut index_data)?;
-                inline_index_records.push(InlineIndexRecord {
-                    index_id: index_builder.index_def().index_id,
-                    index_data,
-                });
-            }
-            counter = 0;
-            index_builders = index_manager.new_index_builders()?;
-        }
-    }
-    drop(chunk_stream);
-
-    // build inline index records for left rows
-    if counter > 0 {
-        for index_builder in index_builders.iter_mut() {
-            if index_builder.is_empty() {
-                continue;
-            }
-            let mut index_data = Vec::new();
-            index_builder.write_bytes(&mut index_data)?;
-            inline_index_records.push(InlineIndexRecord {
-                index_id: index_builder.index_def().index_id,
-                index_data,
-            });
-        }
-    }
-
-    Ok(inline_index_records)
+    let index_builders = index_manager.new_index_builders()?;
+    build_inline_indexes_with_builders(tx_helper, table_id, table_schema, index_builders).await
 }
 
 pub(crate) async fn build_inline_indexes_by_ids(
@@ -402,6 +352,16 @@ pub(crate) async fn build_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<Vec<InlineIndexRecord>> {
+    let index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
+    build_inline_indexes_with_builders(tx_helper, table_id, table_schema, index_builders).await
+}
+
+async fn build_inline_indexes_with_builders(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    mut index_builders: Vec<Box<dyn IndexBuilder>>,
+) -> ILResult<Vec<InlineIndexRecord>> {
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
         .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
@@ -409,9 +369,8 @@ pub(crate) async fn build_inline_indexes_by_ids(
     let mut chunk_stream = row_stream.chunks(100);
 
     let mut inline_index_records = Vec::new();
-
-    let mut index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
     let mut counter = 0;
+
     while let Some(row_chunk) = chunk_stream.next().await {
         let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
         counter += rows.len();
@@ -421,37 +380,34 @@ pub(crate) async fn build_inline_indexes_by_ids(
         }
 
         if counter >= 1000 {
-            for index_builder in index_builders.iter_mut() {
-                if index_builder.is_empty() {
-                    continue;
-                }
-                let mut index_data = Vec::new();
-                index_builder.write_bytes(&mut index_data)?;
-                inline_index_records.push(InlineIndexRecord {
-                    index_id: index_builder.index_def().index_id,
-                    index_data,
-                });
-            }
+            flush_index_builders(&mut index_builders, &mut inline_index_records)?;
             counter = 0;
-            index_builders = index_manager.new_index_builders_by_ids(index_ids)?;
         }
     }
     drop(chunk_stream);
 
     // build inline index records for left rows
     if counter > 0 {
-        for index_builder in index_builders.iter_mut() {
-            if index_builder.is_empty() {
-                continue;
-            }
-            let mut index_data = Vec::new();
-            index_builder.write_bytes(&mut index_data)?;
-            inline_index_records.push(InlineIndexRecord {
-                index_id: index_builder.index_def().index_id,
-                index_data,
-            });
-        }
+        flush_index_builders(&mut index_builders, &mut inline_index_records)?;
     }
 
     Ok(inline_index_records)
+}
+
+fn flush_index_builders(
+    index_builders: &mut [Box<dyn IndexBuilder>],
+    inline_index_records: &mut Vec<InlineIndexRecord>,
+) -> ILResult<()> {
+    for index_builder in index_builders.iter_mut() {
+        if index_builder.is_empty() {
+            continue;
+        }
+        let mut index_data = Vec::new();
+        index_builder.write_bytes(&mut index_data)?;
+        inline_index_records.push(InlineIndexRecord {
+            index_id: index_builder.index_def().index_id,
+            index_data,
+        });
+    }
+    Ok(())
 }

--- a/indexlake/src/table/insert.rs
+++ b/indexlake/src/table/insert.rs
@@ -108,6 +108,30 @@ pub(crate) async fn process_insert_into_inline_rows_with_tx(
     Ok(())
 }
 
+/// Insert inline rows without building inline indexes.
+/// Used by update path where index rebuild is handled separately.
+pub(crate) async fn insert_inline_rows_only_with_tx(
+    tx_helper: &mut TransactionHelper,
+    table: &Table,
+    batches: &[RecordBatch],
+) -> ILResult<()> {
+    if batches.is_empty() {
+        return Ok(());
+    }
+
+    let inline_field_names = batches[0]
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    tx_helper
+        .insert_inline_rows(&table.table_id, &inline_field_names, batches)
+        .await?;
+
+    Ok(())
+}
+
 pub(crate) async fn process_bypass_insert(
     table: &Table,
     batch_stream: RecordBatchStream,

--- a/indexlake/src/table/update.rs
+++ b/indexlake/src/table/update.rs
@@ -10,7 +10,8 @@ use crate::catalog::{CatalogSchema, DataFileRecord, TransactionHelper, rows_to_r
 use crate::expr::Expr;
 use crate::storage::{Storage, read_data_file_by_record, read_row_id_array_from_data_file};
 use crate::table::{
-    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes_by_ids,
+    Table, TableSchemaRef, insert_inline_rows_only_with_tx,
+    process_insert_into_inline_rows_with_tx, rebuild_inline_indexes_by_ids,
 };
 use crate::utils::{extract_row_ids_from_record_batch, fixed_size_binary_array_to_uuids};
 use crate::{ILError, ILResult, RecordBatchStream};
@@ -137,7 +138,7 @@ pub(crate) async fn update_inline_rows(
         tx_helper
             .delete_inline_rows(&table.table_id, &[], Some(&updated_row_ids))
             .await?;
-        process_insert_into_inline_rows_with_tx(tx_helper, table, &updated_batches).await?;
+        insert_inline_rows_only_with_tx(tx_helper, table, &updated_batches).await?;
         Ok(updated_row_ids.len())
     }
 }

--- a/indexlake/src/table/update.rs
+++ b/indexlake/src/table/update.rs
@@ -10,7 +10,7 @@ use crate::catalog::{CatalogSchema, DataFileRecord, TransactionHelper, rows_to_r
 use crate::expr::Expr;
 use crate::storage::{Storage, read_data_file_by_record, read_row_id_array_from_data_file};
 use crate::table::{
-    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes,
+    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes_by_ids,
 };
 use crate::utils::{extract_row_ids_from_record_batch, fixed_size_binary_array_to_uuids};
 use crate::{ILError, ILResult, RecordBatchStream};
@@ -49,15 +49,23 @@ pub(crate) async fn process_update_by_condition(
 ) -> ILResult<usize> {
     let inline_update_count = update_inline_rows(tx_helper, table, &update).await?;
 
-    // TODO this could be optimized into update_inline_rows function
+    // Phase 1 optimization: only rebuild indexes affected by the update
     if inline_update_count != 0 {
-        rebuild_inline_indexes(
-            tx_helper,
-            &table.table_id,
-            &table.table_schema,
-            &table.index_manager,
-        )
-        .await?;
+        let updated_field_ids: Vec<String> = update.set_map.keys().cloned().collect();
+        let affected_index_ids = table
+            .index_manager
+            .index_ids_by_field_ids(&updated_field_ids);
+
+        if !affected_index_ids.is_empty() {
+            rebuild_inline_indexes_by_ids(
+                tx_helper,
+                &table.table_id,
+                &table.table_schema,
+                &table.index_manager,
+                &affected_index_ids,
+            )
+            .await?;
+        }
     }
 
     let data_file_records = tx_helper.get_data_files(&table.table_id).await?;

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -1,14 +1,16 @@
-use arrow::array::{Float32Builder, ListBuilder};
-use arrow::datatypes::{DataType, Field};
+use arrow::array::{Float32Builder, Int32Array, ListBuilder, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
 use indexlake::Client;
 use indexlake::catalog::{Catalog, INTERNAL_ROW_ID_FIELD_NAME, Scalar};
 use indexlake::expr::{col, lit};
+use indexlake::index::IndexKind;
 use indexlake::storage::{DataFileFormat, Storage};
-use indexlake::table::TableUpdate;
+use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate};
+use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use indexlake_integration_tests::data::{
     prepare_simple_testing_table, prepare_simple_vector_table,
 };
-use indexlake_integration_tests::utils::{full_table_scan, read_first_row_id_bytes_from_table};
+use indexlake_integration_tests::utils::{full_table_scan, read_first_row_id_bytes_from_table, table_scan};
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite, init_env_logger, storage_fs, storage_s3,
 };
@@ -152,7 +154,212 @@ async fn update_table_by_catalog_unsupported_condition(
 | 2  | [20.0, 20.0, 20.0] |
 | 10 | [30.0, 30.0, 30.0] |
 | 10 | [40.0, 40.0, 40.0] |
-+----+--------------------+"#,
++----+--------------------+
+"#,
     );
+    Ok(())
+}
+
+async fn prepare_table_with_two_btree_indexes(
+    client: &Client,
+    format: DataFileFormat,
+) -> Result<indexlake::table::Table, Box<dyn std::error::Error>> {
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+    // Keep rows inline so inline indexes are used
+    let table_config = TableConfig {
+        inline_row_count_limit: 100,
+        parquet_row_group_size: 2,
+        preferred_data_file_format: format,
+    };
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: table_config,
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    let record_batch = RecordBatch::try_new(
+        table_schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            Arc::new(Int32Array::from(vec![20, 21, 22, 23])),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![record_batch]))
+        .await?;
+
+    // Create btree index on name
+    let name_index_creation = IndexCreation {
+        name: "name_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["name".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(name_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Create btree index on age
+    let age_index_creation = IndexCreation {
+        name: "age_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["age".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(age_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    let table = client.load_table(&namespace_name, &table_name).await?;
+    Ok(table)
+}
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn update_non_index_column_does_not_affect_indexes(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(BTreeIndexKind));
+
+    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+
+    // Update non-index column 'id'
+    let update = TableUpdate {
+        set_map: HashMap::from([("id".to_string(), lit(100i32))]),
+        condition: col("name").eq(lit("Alice")),
+    };
+    let update_count = table.update(update).await?;
+    assert_eq!(update_count, 1);
+
+    // Query via name index - should return exactly 1 row for Alice
+    let scan = TableScan::default()
+        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string()))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query after non-index update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+-----+-------+-----+
+| id  | name  | age |
++-----+-------+-----+
+| 100 | Alice | 20  |
++-----+-------+-----+"#
+    );
+
+    // Query via age index - should return exactly 1 row for age=20
+    let scan = TableScan::default()
+        .with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("age index query after non-index update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+-----+-------+-----+
+| id  | name  | age |
++-----+-------+-----+
+| 100 | Alice | 20  |
++-----+-------+-----+"#
+    );
+
+    Ok(())
+}
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn update_one_index_column_only_affects_that_index(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(BTreeIndexKind));
+
+    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+
+    // Update indexed column 'name' only
+    let update = TableUpdate {
+        set_map: HashMap::from([("name".to_string(), lit(Scalar::Utf8(Some("Alicia".to_string()))))]),
+        condition: col("name").eq(lit("Alice")),
+    };
+    let update_count = table.update(update).await?;
+    assert_eq!(update_count, 1);
+
+    // Query via name index for new name - should return exactly 1 row
+    let scan = TableScan::default()
+        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alicia".to_string()))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query for new name after update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+--------+-----+
+| id | name   | age |
++----+--------+-----+
+| 1  | Alicia | 20  |
++----+--------+-----+"#
+    );
+
+    // Query via name index for old name - should return nothing
+    let scan = TableScan::default()
+        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string()))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query for old name after update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+------+-----+
+| id | name | age |
++----+------+-----+
++----+------+-----+"#
+    );
+
+    // Query via age index - should still work correctly, returning 1 row for age=20
+    let scan = TableScan::default()
+        .with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("age index query after name update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+--------+-----+
+| id | name   | age |
++----+--------+-----+
+| 1  | Alicia | 20  |
++----+--------+-----+"#
+    );
+
     Ok(())
 }

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -1,16 +1,22 @@
 use arrow::array::{Float32Builder, Int32Array, ListBuilder, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use indexlake::Client;
-use indexlake::catalog::{Catalog, INTERNAL_ROW_ID_FIELD_NAME, Scalar};
+use indexlake::catalog::{
+    Catalog, CatalogDataType, CatalogSchema, Column, INTERNAL_ROW_ID_FIELD_NAME, Scalar,
+};
 use indexlake::expr::{col, lit};
 use indexlake::index::IndexKind;
 use indexlake::storage::{DataFileFormat, Storage};
-use indexlake::table::{IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate};
+use indexlake::table::{
+    IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate,
+};
 use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use indexlake_integration_tests::data::{
     prepare_simple_testing_table, prepare_simple_vector_table,
 };
-use indexlake_integration_tests::utils::{full_table_scan, read_first_row_id_bytes_from_table, table_scan};
+use indexlake_integration_tests::utils::{
+    full_table_scan, read_first_row_id_bytes_from_table, table_scan,
+};
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite, init_env_logger, storage_fs, storage_s3,
 };
@@ -163,7 +169,7 @@ async fn update_table_by_catalog_unsupported_condition(
 async fn prepare_table_with_two_btree_indexes(
     client: &Client,
     format: DataFileFormat,
-) -> Result<indexlake::table::Table, Box<dyn std::error::Error>> {
+) -> Result<(indexlake::table::Table, Arc<dyn Catalog>), Box<dyn std::error::Error>> {
     let namespace_name = uuid::Uuid::new_v4().to_string();
     client.create_namespace(&namespace_name, true).await?;
 
@@ -171,6 +177,11 @@ async fn prepare_table_with_two_btree_indexes(
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, false),
         Field::new("age", DataType::Int32, false),
+        Field::new_list(
+            "vector",
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            false,
+        ),
     ]));
     // Keep rows inline so inline indexes are used
     let table_config = TableConfig {
@@ -189,12 +200,25 @@ async fn prepare_table_with_two_btree_indexes(
     client.create_table(table_creation).await?;
     let table = client.load_table(&namespace_name, &table_name).await?;
 
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut vector_builder = ListBuilder::new(Float32Builder::new()).with_field(list_inner_field);
+    for vector in [
+        [10.0, 10.0, 10.0],
+        [20.0, 20.0, 20.0],
+        [30.0, 30.0, 30.0],
+        [40.0, 40.0, 40.0],
+    ] {
+        vector_builder.values().append_slice(&vector);
+        vector_builder.append(true);
+    }
+
     let record_batch = RecordBatch::try_new(
         table_schema.clone(),
         vec![
             Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
             Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
             Arc::new(Int32Array::from(vec![20, 21, 22, 23])),
+            Arc::new(vector_builder.finish()),
         ],
     )?;
     table
@@ -228,7 +252,22 @@ async fn prepare_table_with_two_btree_indexes(
 
     // Reload table after create_index consumes self
     let table = client.load_table(&namespace_name, &table_name).await?;
-    Ok(table)
+    Ok((table, client.catalog.clone()))
+}
+
+async fn count_inline_index_records(catalog: Arc<dyn Catalog>) -> indexlake::ILResult<i64> {
+    let schema = Arc::new(CatalogSchema::new(vec![Column::new(
+        "count",
+        CatalogDataType::Int64,
+        false,
+    )]));
+    let mut stream = catalog
+        .query("SELECT COUNT(1) FROM indexlake_inline_index", schema)
+        .await?;
+    let row = futures::TryStreamExt::try_next(&mut stream)
+        .await?
+        .expect("count query returns one row");
+    Ok(row.int64(0)?.expect("count is not null"))
 }
 
 #[rstest::rstest]
@@ -250,42 +289,53 @@ async fn update_non_index_column_does_not_affect_indexes(
     let mut client = Client::new(catalog, storage);
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
-    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+
+    // Use a catalog-unsupported condition so the inline update path deletes
+    // matched rows and reinserts updated batches.
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut list_builder =
+        ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
+    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.append(true);
+    let scalar = Scalar::List(Arc::new(list_builder.finish()));
 
     // Update non-index column 'id'
     let update = TableUpdate {
         set_map: HashMap::from([("id".to_string(), lit(100i32))]),
-        condition: col("name").eq(lit("Alice")),
+        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
     };
     let update_count = table.update(update).await?;
     assert_eq!(update_count, 1);
+    assert_eq!(count_inline_index_records(catalog).await?, 2);
 
     // Query via name index - should return exactly 1 row for Alice
-    let scan = TableScan::default()
-        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string()))))]);
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+    ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query after non-index update:\n{}", table_str);
     assert_eq!(
         table_str,
-        r#"+-----+-------+-----+
-| id  | name  | age |
-+-----+-------+-----+
-| 100 | Alice | 20  |
-+-----+-------+-----+"#
+        r#"+-----+-------+-----+--------------------+
+| id  | name  | age | vector             |
++-----+-------+-----+--------------------+
+| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
++-----+-------+-----+--------------------+"#
     );
 
     // Query via age index - should return exactly 1 row for age=20
-    let scan = TableScan::default()
-        .with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
     let table_str = table_scan(&table, scan).await?;
     println!("age index query after non-index update:\n{}", table_str);
     assert_eq!(
         table_str,
-        r#"+-----+-------+-----+
-| id  | name  | age |
-+-----+-------+-----+
-| 100 | Alice | 20  |
-+-----+-------+-----+"#
+        r#"+-----+-------+-----+--------------------+
+| id  | name  | age | vector             |
++-----+-------+-----+--------------------+
+| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
++-----+-------+-----+--------------------+"#
     );
 
     Ok(())
@@ -310,55 +360,70 @@ async fn update_one_index_column_only_affects_that_index(
     let mut client = Client::new(catalog, storage);
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
-    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+
+    // Use a catalog-unsupported condition so the inline update path deletes
+    // matched rows and reinserts updated batches.
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut list_builder =
+        ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
+    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.append(true);
+    let scalar = Scalar::List(Arc::new(list_builder.finish()));
 
     // Update indexed column 'name' only
     let update = TableUpdate {
-        set_map: HashMap::from([("name".to_string(), lit(Scalar::Utf8(Some("Alicia".to_string()))))]),
-        condition: col("name").eq(lit("Alice")),
+        set_map: HashMap::from([(
+            "name".to_string(),
+            lit(Scalar::Utf8(Some("Alicia".to_string()))),
+        )]),
+        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
     };
     let update_count = table.update(update).await?;
     assert_eq!(update_count, 1);
+    assert_eq!(count_inline_index_records(catalog).await?, 2);
 
     // Query via name index for new name - should return exactly 1 row
-    let scan = TableScan::default()
-        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alicia".to_string()))))]);
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alicia".to_string())))),
+    ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query for new name after update:\n{}", table_str);
     assert_eq!(
         table_str,
-        r#"+----+--------+-----+
-| id | name   | age |
-+----+--------+-----+
-| 1  | Alicia | 20  |
-+----+--------+-----+"#
+        r#"+----+--------+-----+--------------------+
+| id | name   | age | vector             |
++----+--------+-----+--------------------+
+| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
++----+--------+-----+--------------------+"#
     );
 
     // Query via name index for old name - should return nothing
-    let scan = TableScan::default()
-        .with_filters(vec![col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string()))))]);
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+    ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query for old name after update:\n{}", table_str);
     assert_eq!(
         table_str,
-        r#"+----+------+-----+
-| id | name | age |
-+----+------+-----+
-+----+------+-----+"#
+        r#"+----+------+-----+--------+
+| id | name | age | vector |
++----+------+-----+--------+
++----+------+-----+--------+"#
     );
 
     // Query via age index - should still work correctly, returning 1 row for age=20
-    let scan = TableScan::default()
-        .with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
     let table_str = table_scan(&table, scan).await?;
     println!("age index query after name update:\n{}", table_str);
     assert_eq!(
         table_str,
-        r#"+----+--------+-----+
-| id | name   | age |
-+----+--------+-----+
-| 1  | Alicia | 20  |
-+----+--------+-----+"#
+        r#"+----+--------+-----+--------------------+
+| id | name   | age | vector             |
++----+--------+-----+--------------------+
+| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
++----+--------+-----+--------------------+"#
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Optimize inline index rebuild during row updates to reduce write amplification for small tables with row-by-row updates.

## Changes

1. **Skip rebuild when no index columns are touched**
   - Check if updated columns are part of any index
   - If not, skip inline index rebuild entirely

2. **Selective rebuild by affected index IDs**
   - Only rebuild indexes whose key columns are in the update's `set_map`
   - Add `index_ids_by_field_ids()` to `IndexManager` to find affected indexes
   - Add `new_index_builders_by_ids()` to create builders for specific indexes only

3. **New functions in dump module**
   - `build_inline_indexes_by_ids()`: Build only specified inline indexes
   - `rebuild_inline_indexes_by_ids()`: Rebuild only specified inline indexes

4. **Fix correctness issue (post-review)**
   - The non-catalog-filter branch of `update_inline_rows` was using `process_insert_into_inline_rows_with_tx` which builds ALL inline indexes when re-inserting updated rows
   - This caused unaffected indexes to get duplicate records while `rebuild_inline_indexes_by_ids` only cleaned up affected indexes
   - Added `insert_inline_rows_only_with_tx()` that only inserts rows without building inline index records
   - Used in `update_inline_rows` so index rebuild is fully controlled by the outer logic

## Before vs After

- **Before**: Every inline row update triggers full scan + delete all indexes + rebuild all indexes
- **After**: 
  - Non-index column updates: no rebuild
  - Partial index column updates: only rebuild affected indexes
  - Unaffected indexes are not polluted by the re-insert path

## Verification

- `cargo check` passes
- `cargo test --lib` passes (9/9)
- `cargo clippy -- -D warnings` passes

## Related

Phase 1 of inline table index optimization plan discussed in #indexlake:5db45278

cc @Alice for review
