### PR TITLE
feat: selective rebuild inline indexes on update

### DIFF
--- a/indexlake/src/index/manager.rs
+++ b/indexlake/src/index/manager.rs
@@ -60,23 +60,6 @@ impl IndexManager {
             .collect()
     }
 
-    pub(crate) fn new_index_builders_by_ids(
-        &self,
-        index_ids: &[Uuid],
-    ) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
-        self.indexes
-            .iter()
-            .filter(|index_def| index_ids.contains(&index_def.index_id))
-            .map(|index_def| {
-                let index_kind = self
-                    .kinds
-                    .get(&index_def.kind)
-                    .expect("Index kind not found");
-                index_kind.builder(index_def)
-            })
-            .collect()
-    }
-
     pub(crate) fn supports_filter(&self, filter: &Expr) -> ILResult<FilterSupport> {
         let mut supports = FilterSupport::Unsupported;
         for index_def in &self.indexes {
@@ -105,9 +88,15 @@ impl IndexManager {
         })
     }
 
-    pub(crate) fn new_index_builders(&self) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
+    pub(crate) fn new_index_builders(
+        &self,
+        index_ids: Option<&[Uuid]>,
+    ) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
         self.indexes
             .iter()
+            .filter(|index_def| {
+                index_ids.is_none_or(|ids| ids.contains(&index_def.index_id))
+            })
             .map(|index_def| {
                 let index_kind = self
                     .kinds

--- a/indexlake/src/index/manager.rs
+++ b/indexlake/src/index/manager.rs
@@ -94,9 +94,7 @@ impl IndexManager {
     ) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
         self.indexes
             .iter()
-            .filter(|index_def| {
-                index_ids.is_none_or(|ids| ids.contains(&index_def.index_id))
-            })
+            .filter(|index_def| index_ids.is_none_or(|ids| ids.contains(&index_def.index_id)))
             .map(|index_def| {
                 let index_kind = self
                     .kinds

--- a/indexlake/src/index/manager.rs
+++ b/indexlake/src/index/manager.rs
@@ -48,6 +48,35 @@ impl IndexManager {
             .any(|def| def.key_columns.contains(&field_id_str))
     }
 
+    pub(crate) fn index_ids_by_field_ids(&self, field_ids: &[String]) -> Vec<Uuid> {
+        self.indexes
+            .iter()
+            .filter(|index_def| {
+                field_ids
+                    .iter()
+                    .any(|field_id| index_def.key_columns.contains(field_id))
+            })
+            .map(|index_def| index_def.index_id)
+            .collect()
+    }
+
+    pub(crate) fn new_index_builders_by_ids(
+        &self,
+        index_ids: &[Uuid],
+    ) -> ILResult<Vec<Box<dyn IndexBuilder>>> {
+        self.indexes
+            .iter()
+            .filter(|index_def| index_ids.contains(&index_def.index_id))
+            .map(|index_def| {
+                let index_kind = self
+                    .kinds
+                    .get(&index_def.kind)
+                    .expect("Index kind not found");
+                index_kind.builder(index_def)
+            })
+            .collect()
+    }
+
     pub(crate) fn supports_filter(&self, filter: &Expr) -> ILResult<FilterSupport> {
         let mut supports = FilterSupport::Unsupported;
         for index_def in &self.indexes {

--- a/indexlake/src/table/alter.rs
+++ b/indexlake/src/table/alter.rs
@@ -214,7 +214,7 @@ async fn rewrite_data_files_add_column(
                 table.config.parquet_row_group_size,
                 table.config.preferred_data_file_format,
             )?;
-            let mut index_builders = table.index_manager.new_index_builders()?;
+            let mut index_builders = table.index_manager.new_index_builders(None)?;
 
             let mut stream = read_data_file_by_record(
                 table.storage.as_ref(),

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -301,10 +301,7 @@ pub(crate) async fn rebuild_inline_indexes(
         .await?;
 
     // delete old inline index records
-    let ids_to_delete = index_ids.map_or_else(
-        || index_manager.index_ids(),
-        |ids| ids.to_vec(),
-    );
+    let ids_to_delete = index_ids.map_or_else(|| index_manager.index_ids(), |ids| ids.to_vec());
     tx_helper.delete_inline_indexes(&ids_to_delete).await?;
 
     // insert inline index records

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -292,13 +292,11 @@ pub(crate) async fn rebuild_inline_indexes(
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
 ) -> ILResult<()> {
-    let inline_index_records = full_build_inline_index_records(
-        tx_helper,
-        table_id,
-        table_schema,
-        || index_manager.new_index_builders(None),
-    )
-    .await?;
+    let inline_index_records =
+        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
+            index_manager.new_index_builders(None)
+        })
+        .await?;
 
     // delete old inline index records
     tx_helper
@@ -320,13 +318,11 @@ pub(crate) async fn rebuild_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<()> {
-    let inline_index_records = full_build_inline_index_records(
-        tx_helper,
-        table_id,
-        table_schema,
-        || index_manager.new_index_builders(Some(index_ids)),
-    )
-    .await?;
+    let inline_index_records =
+        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
+            index_manager.new_index_builders(Some(index_ids))
+        })
+        .await?;
 
     // delete old inline index records for specified index_ids only
     tx_helper.delete_inline_indexes(index_ids).await?;

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -292,8 +292,13 @@ pub(crate) async fn rebuild_inline_indexes(
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
 ) -> ILResult<()> {
-    let inline_index_records =
-        build_all_inline_indexes(tx_helper, table_id, table_schema, index_manager).await?;
+    let inline_index_records = full_build_inline_index_records(
+        tx_helper,
+        table_id,
+        table_schema,
+        || index_manager.new_index_builders(None),
+    )
+    .await?;
 
     // delete old inline index records
     tx_helper
@@ -315,9 +320,13 @@ pub(crate) async fn rebuild_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<()> {
-    let inline_index_records =
-        build_inline_indexes_by_ids(tx_helper, table_id, table_schema, index_manager, index_ids)
-            .await?;
+    let inline_index_records = full_build_inline_index_records(
+        tx_helper,
+        table_id,
+        table_schema,
+        || index_manager.new_index_builders(Some(index_ids)),
+    )
+    .await?;
 
     // delete old inline index records for specified index_ids only
     tx_helper.delete_inline_indexes(index_ids).await?;
@@ -328,31 +337,6 @@ pub(crate) async fn rebuild_inline_indexes_by_ids(
         .await?;
 
     Ok(())
-}
-
-pub(crate) async fn build_all_inline_indexes(
-    tx_helper: &mut TransactionHelper,
-    table_id: &Uuid,
-    table_schema: &TableSchemaRef,
-    index_manager: &IndexManager,
-) -> ILResult<Vec<InlineIndexRecord>> {
-    full_build_inline_index_records(tx_helper, table_id, table_schema, || {
-        index_manager.new_index_builders(None)
-    })
-    .await
-}
-
-pub(crate) async fn build_inline_indexes_by_ids(
-    tx_helper: &mut TransactionHelper,
-    table_id: &Uuid,
-    table_schema: &TableSchemaRef,
-    index_manager: &IndexManager,
-    index_ids: &[Uuid],
-) -> ILResult<Vec<InlineIndexRecord>> {
-    full_build_inline_index_records(tx_helper, table_id, table_schema, || {
-        index_manager.new_index_builders(Some(index_ids))
-    })
-    .await
 }
 
 async fn full_build_inline_index_records(

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -222,6 +222,7 @@ impl DumpTask {
             &self.table_id,
             &self.table_schema,
             &self.index_manager,
+            None,
         )
         .await?;
 
@@ -291,41 +292,20 @@ pub(crate) async fn rebuild_inline_indexes(
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
+    index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
     let inline_index_records =
         full_build_inline_index_records(tx_helper, table_id, table_schema, || {
-            index_manager.new_index_builders(None)
+            index_manager.new_index_builders(index_ids)
         })
         .await?;
 
     // delete old inline index records
-    tx_helper
-        .delete_inline_indexes(&index_manager.index_ids())
-        .await?;
-
-    // insert inline index records
-    tx_helper
-        .insert_inline_indexes(&inline_index_records)
-        .await?;
-
-    Ok(())
-}
-
-pub(crate) async fn rebuild_inline_indexes_by_ids(
-    tx_helper: &mut TransactionHelper,
-    table_id: &Uuid,
-    table_schema: &TableSchemaRef,
-    index_manager: &IndexManager,
-    index_ids: &[Uuid],
-) -> ILResult<()> {
-    let inline_index_records =
-        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
-            index_manager.new_index_builders(Some(index_ids))
-        })
-        .await?;
-
-    // delete old inline index records for specified index_ids only
-    tx_helper.delete_inline_indexes(index_ids).await?;
+    let ids_to_delete = index_ids.map_or_else(
+        || index_manager.index_ids(),
+        |ids| ids.to_vec(),
+    );
+    tx_helper.delete_inline_indexes(&ids_to_delete).await?;
 
     // insert inline index records
     tx_helper

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -308,11 +308,58 @@ pub(crate) async fn rebuild_inline_indexes(
     Ok(())
 }
 
+pub(crate) async fn rebuild_inline_indexes_by_ids(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    index_manager: &IndexManager,
+    index_ids: &[Uuid],
+) -> ILResult<()> {
+    let inline_index_records =
+        build_inline_indexes_by_ids(tx_helper, table_id, table_schema, index_manager, index_ids)
+            .await?;
+
+    // delete old inline index records for specified index_ids only
+    tx_helper.delete_inline_indexes(index_ids).await?;
+
+    // insert inline index records
+    tx_helper
+        .insert_inline_indexes(&inline_index_records)
+        .await?;
+
+    Ok(())
+}
+
 pub(crate) async fn build_all_inline_indexes(
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
+) -> ILResult<Vec<InlineIndexRecord>> {
+    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders()
+    })
+    .await
+}
+
+pub(crate) async fn build_inline_indexes_by_ids(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    index_manager: &IndexManager,
+    index_ids: &[Uuid],
+) -> ILResult<Vec<InlineIndexRecord>> {
+    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders_by_ids(index_ids)
+    })
+    .await
+}
+
+async fn build_inline_indexes_with_builder_factory(
+    tx_helper: &mut TransactionHelper,
+    table_id: &Uuid,
+    table_schema: &TableSchemaRef,
+    mut new_index_builders: impl FnMut() -> ILResult<Vec<Box<dyn IndexBuilder>>>,
 ) -> ILResult<Vec<InlineIndexRecord>> {
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
@@ -321,8 +368,7 @@ pub(crate) async fn build_all_inline_indexes(
     let mut chunk_stream = row_stream.chunks(100);
 
     let mut inline_index_records = Vec::new();
-
-    let mut index_builders = index_manager.new_index_builders()?;
+    let mut index_builders = new_index_builders()?;
     let mut counter = 0;
     while let Some(row_chunk) = chunk_stream.next().await {
         let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
@@ -333,37 +379,35 @@ pub(crate) async fn build_all_inline_indexes(
         }
 
         if counter >= 1000 {
-            for index_builder in index_builders.iter_mut() {
-                if index_builder.is_empty() {
-                    continue;
-                }
-                let mut index_data = Vec::new();
-                index_builder.write_bytes(&mut index_data)?;
-                inline_index_records.push(InlineIndexRecord {
-                    index_id: index_builder.index_def().index_id,
-                    index_data,
-                });
-            }
+            flush_index_builders(&mut index_builders, &mut inline_index_records)?;
             counter = 0;
-            index_builders = index_manager.new_index_builders()?;
+            index_builders = new_index_builders()?;
         }
     }
     drop(chunk_stream);
 
     // build inline index records for left rows
     if counter > 0 {
-        for index_builder in index_builders.iter_mut() {
-            if index_builder.is_empty() {
-                continue;
-            }
-            let mut index_data = Vec::new();
-            index_builder.write_bytes(&mut index_data)?;
-            inline_index_records.push(InlineIndexRecord {
-                index_id: index_builder.index_def().index_id,
-                index_data,
-            });
-        }
+        flush_index_builders(&mut index_builders, &mut inline_index_records)?;
     }
 
     Ok(inline_index_records)
+}
+
+fn flush_index_builders(
+    index_builders: &mut [Box<dyn IndexBuilder>],
+    inline_index_records: &mut Vec<InlineIndexRecord>,
+) -> ILResult<()> {
+    for index_builder in index_builders.iter_mut() {
+        if index_builder.is_empty() {
+            continue;
+        }
+        let mut index_data = Vec::new();
+        index_builder.write_bytes(&mut index_data)?;
+        inline_index_records.push(InlineIndexRecord {
+            index_id: index_builder.index_def().index_id,
+            index_data,
+        });
+    }
+    Ok(())
 }

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -133,7 +133,7 @@ impl DumpTask {
                 self.table_config.preferred_data_file_format,
             );
 
-            let mut index_builders = self.index_manager.new_index_builders()?;
+            let mut index_builders = self.index_manager.new_index_builders(None)?;
 
             let row_ids = match self.table_config.preferred_data_file_format {
                 DataFileFormat::ParquetV1 | DataFileFormat::ParquetV2 => {
@@ -336,8 +336,8 @@ pub(crate) async fn build_all_inline_indexes(
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
 ) -> ILResult<Vec<InlineIndexRecord>> {
-    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
-        index_manager.new_index_builders()
+    full_build_inline_index_records(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders(None)
     })
     .await
 }
@@ -349,13 +349,13 @@ pub(crate) async fn build_inline_indexes_by_ids(
     index_manager: &IndexManager,
     index_ids: &[Uuid],
 ) -> ILResult<Vec<InlineIndexRecord>> {
-    build_inline_indexes_with_builder_factory(tx_helper, table_id, table_schema, || {
-        index_manager.new_index_builders_by_ids(index_ids)
+    full_build_inline_index_records(tx_helper, table_id, table_schema, || {
+        index_manager.new_index_builders(Some(index_ids))
     })
     .await
 }
 
-async fn build_inline_indexes_with_builder_factory(
+async fn full_build_inline_index_records(
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,

--- a/indexlake/src/table/insert.rs
+++ b/indexlake/src/table/insert.rs
@@ -51,7 +51,7 @@ pub(crate) async fn process_insert_into_inline_rows_without_tx(
         return Ok(());
     }
 
-    let index_builders = table.index_manager.new_index_builders()?;
+    let index_builders = table.index_manager.new_index_builders(None)?;
     let inline_index_records = build_inline_indexes(batches, index_builders)?;
 
     // insert inline rows
@@ -86,7 +86,7 @@ pub(crate) async fn process_insert_into_inline_rows_with_tx(
         return Ok(());
     }
 
-    let index_builders = table.index_manager.new_index_builders()?;
+    let index_builders = table.index_manager.new_index_builders(None)?;
     let inline_index_records = build_inline_indexes(batches, index_builders)?;
 
     // insert inline rows
@@ -253,7 +253,7 @@ async fn create_new_parquet_writer(
         table.config.parquet_row_group_size,
         table.config.preferred_data_file_format,
     )?;
-    let index_builders = table.index_manager.new_index_builders()?;
+    let index_builders = table.index_manager.new_index_builders(None)?;
 
     Ok((data_file_id, relative_path, arrow_writer, index_builders))
 }

--- a/indexlake/src/table/insert.rs
+++ b/indexlake/src/table/insert.rs
@@ -108,6 +108,30 @@ pub(crate) async fn process_insert_into_inline_rows_with_tx(
     Ok(())
 }
 
+/// Insert inline rows without building inline indexes.
+/// Used by update path where index rebuild is handled separately.
+pub(crate) async fn insert_inline_rows_only_with_tx(
+    tx_helper: &mut TransactionHelper,
+    table: &Table,
+    batches: &[RecordBatch],
+) -> ILResult<()> {
+    if batches.is_empty() {
+        return Ok(());
+    }
+
+    let inline_field_names = batches[0]
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    tx_helper
+        .insert_inline_rows(&table.table_id, &inline_field_names, batches)
+        .await?;
+
+    Ok(())
+}
+
 pub(crate) async fn process_bypass_insert(
     table: &Table,
     batch_stream: RecordBatchStream,

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -130,7 +130,7 @@ async fn merge_data_files(table: &Table, valid_row_threshold: usize) -> ILResult
             .map(|i| &matched_data_files[*i])
             .collect::<Vec<_>>();
 
-        let mut index_builders = table.index_manager.new_index_builders()?;
+        let mut index_builders = table.index_manager.new_index_builders(None)?;
 
         let data_file_id = Uuid::now_v7();
         let relative_path = DataFileRecord::build_relative_path(

--- a/indexlake/src/table/update.rs
+++ b/indexlake/src/table/update.rs
@@ -14,7 +14,7 @@ use crate::catalog::{
 use crate::expr::{Expr, merge_filters, split_conjunction_filters, visited_columns};
 use crate::storage::{Storage, read_data_file_by_record, read_row_id_array_from_data_file};
 use crate::table::{
-    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes_by_ids,
+    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes,
 };
 use crate::utils::{extract_row_ids_from_record_batch, fixed_size_binary_array_to_uuids};
 use crate::{ILError, ILResult, RecordBatchStream};
@@ -61,12 +61,12 @@ pub(crate) async fn process_update_by_condition(
             .index_ids_by_field_ids(&updated_field_ids);
 
         if !affected_index_ids.is_empty() {
-            rebuild_inline_indexes_by_ids(
+            rebuild_inline_indexes(
                 tx_helper,
                 &table.table_id,
                 &table.table_schema,
                 &table.index_manager,
-                &affected_index_ids,
+                Some(&affected_index_ids),
             )
             .await?;
         }

--- a/indexlake/src/table/update.rs
+++ b/indexlake/src/table/update.rs
@@ -10,7 +10,8 @@ use crate::catalog::{CatalogSchema, DataFileRecord, TransactionHelper, rows_to_r
 use crate::expr::Expr;
 use crate::storage::{Storage, read_data_file_by_record, read_row_id_array_from_data_file};
 use crate::table::{
-    Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes,
+    Table, TableSchemaRef, insert_inline_rows_only_with_tx,
+    process_insert_into_inline_rows_with_tx, rebuild_inline_indexes_by_ids,
 };
 use crate::utils::{extract_row_ids_from_record_batch, fixed_size_binary_array_to_uuids};
 use crate::{ILError, ILResult, RecordBatchStream};
@@ -51,18 +52,18 @@ pub(crate) async fn process_update_by_condition(
 
     // TODO this could be optimized into update_inline_rows function
     if inline_update_count != 0 {
-        let touches_index = update.set_map.keys().any(|field_id| {
-            Uuid::parse_str(field_id)
-                .ok()
-                .map(|id| table.index_manager.any_index_contains_field(&id))
-                .unwrap_or(false)
-        });
-        if touches_index {
-            rebuild_inline_indexes(
+        let updated_field_ids: Vec<String> = update.set_map.keys().cloned().collect();
+        let affected_index_ids = table
+            .index_manager
+            .index_ids_by_field_ids(&updated_field_ids);
+
+        if !affected_index_ids.is_empty() {
+            rebuild_inline_indexes_by_ids(
                 tx_helper,
                 &table.table_id,
                 &table.table_schema,
                 &table.index_manager,
+                &affected_index_ids,
             )
             .await?;
         }
@@ -137,7 +138,7 @@ pub(crate) async fn update_inline_rows(
         tx_helper
             .delete_inline_rows(&table.table_id, &[], Some(&updated_row_ids))
             .await?;
-        process_insert_into_inline_rows_with_tx(tx_helper, table, &updated_batches).await?;
+        insert_inline_rows_only_with_tx(tx_helper, table, &updated_batches).await?;
         Ok(updated_row_ids.len())
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 indexlake = { workspace = true }
 indexlake-catalog-postgres = { workspace = true }
 indexlake-catalog-sqlite = { workspace = true }
+indexlake-index-btree = { workspace = true }
 indexlake-storage-fs = { workspace = true }
 indexlake-storage-s3 = { workspace = true }
 

--- a/integration-tests/src/data.rs
+++ b/integration-tests/src/data.rs
@@ -6,9 +6,11 @@ use arrow::array::{
 use arrow::datatypes::{DataType, Field, Schema};
 use geo::{Geometry, Point};
 use geozero::{CoordDimensions, ToWkb};
+use indexlake::index::IndexKind;
 use indexlake::storage::DataFileFormat;
-use indexlake::table::{Table, TableConfig, TableCreation, TableInsertion};
+use indexlake::table::{IndexCreation, Table, TableConfig, TableCreation, TableInsertion};
 use indexlake::{Client, ILResult};
+use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 
 use crate::utils::{assert_data_file_count, assert_inline_row_count};
 
@@ -360,4 +362,92 @@ pub async fn prepare_simple_vector_table(
     assert_data_file_count(&table, |count| count > 0).await?;
 
     Ok(table)
+}
+
+pub async fn prepare_table_with_two_btree_indexes(
+    client: &Client,
+    format: DataFileFormat,
+) -> ILResult<Table> {
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+        Field::new_list(
+            "vector",
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            false,
+        ),
+    ]));
+    // Keep rows inline so inline indexes are used
+    let table_config = TableConfig {
+        inline_row_count_limit: 100,
+        parquet_row_group_size: 2,
+        preferred_data_file_format: format,
+    };
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: table_config,
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    let mut vector_builder = ListBuilder::new(Float32Builder::new()).with_field(list_inner_field);
+    for vector in [
+        [10.0, 10.0, 10.0],
+        [20.0, 20.0, 20.0],
+        [30.0, 30.0, 30.0],
+        [40.0, 40.0, 40.0],
+    ] {
+        vector_builder.values().append_slice(&vector);
+        vector_builder.append(true);
+    }
+
+    let record_batch = RecordBatch::try_new(
+        table_schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            Arc::new(Int32Array::from(vec![20, 21, 22, 23])),
+            Arc::new(vector_builder.finish()),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![record_batch]))
+        .await?;
+
+    // Create btree index on name
+    let name_index_creation = IndexCreation {
+        name: "name_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["name".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(name_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Create btree index on age
+    let age_index_creation = IndexCreation {
+        name: "age_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["age".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(age_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    client.load_table(&namespace_name, &table_name).await
 }

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -1,17 +1,25 @@
-use arrow::array::{Float32Builder, ListBuilder};
-use arrow::datatypes::{DataType, Field};
+use arrow::array::{Float32Builder, Int32Array, ListBuilder, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
 use indexlake::Client;
-use indexlake::catalog::{Catalog, INTERNAL_ROW_ID_FIELD_NAME, Scalar};
+use indexlake::catalog::{
+    Catalog, CatalogDataType, CatalogSchema, Column, INTERNAL_ROW_ID_FIELD_NAME, Scalar,
+};
 use indexlake::expr::{col, lit};
+use indexlake::index::IndexKind;
 use indexlake::storage::{DataFileFormat, Storage};
-use indexlake::table::TableUpdate;
+use indexlake::table::{
+    IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate,
+};
 use indexlake_integration_tests::data::{
     prepare_simple_testing_table, prepare_simple_vector_table,
 };
-use indexlake_integration_tests::utils::{full_table_scan, read_first_row_id_bytes_from_table};
+use indexlake_integration_tests::utils::{
+    full_table_scan, read_first_row_id_bytes_from_table, table_scan,
+};
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite, init_env_logger, storage_fs, storage_s3,
 };
+use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -154,5 +162,268 @@ async fn update_table_by_catalog_unsupported_condition(
 | 10 | [40.0, 40.0, 40.0] |
 +----+--------------------+"#,
     );
+    Ok(())
+}
+
+async fn prepare_table_with_two_btree_indexes(
+    client: &Client,
+    format: DataFileFormat,
+) -> Result<(indexlake::table::Table, Arc<dyn Catalog>), Box<dyn std::error::Error>> {
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+        Field::new_list(
+            "vector",
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            false,
+        ),
+    ]));
+    // Keep rows inline so inline indexes are used
+    let table_config = TableConfig {
+        inline_row_count_limit: 100,
+        parquet_row_group_size: 2,
+        preferred_data_file_format: format,
+    };
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: table_config,
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut vector_builder = ListBuilder::new(Float32Builder::new()).with_field(list_inner_field);
+    for vector in [
+        [10.0, 10.0, 10.0],
+        [20.0, 20.0, 20.0],
+        [30.0, 30.0, 30.0],
+        [40.0, 40.0, 40.0],
+    ] {
+        vector_builder.values().append_slice(&vector);
+        vector_builder.append(true);
+    }
+
+    let record_batch = RecordBatch::try_new(
+        table_schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            Arc::new(Int32Array::from(vec![20, 21, 22, 23])),
+            Arc::new(vector_builder.finish()),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![record_batch]))
+        .await?;
+
+    // Create btree index on name
+    let name_index_creation = IndexCreation {
+        name: "name_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["name".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(name_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Create btree index on age
+    let age_index_creation = IndexCreation {
+        name: "age_btree".to_string(),
+        kind: BTreeIndexKind.kind().to_string(),
+        key_columns: vec!["age".to_string()],
+        params: Arc::new(BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(age_index_creation).await?;
+
+    // Reload table after create_index consumes self
+    let table = client.load_table(&namespace_name, &table_name).await?;
+    Ok((table, client.catalog.clone()))
+}
+
+async fn count_inline_index_records(catalog: Arc<dyn Catalog>) -> indexlake::ILResult<i64> {
+    let schema = Arc::new(CatalogSchema::new(vec![Column::new(
+        "count",
+        CatalogDataType::Int64,
+        false,
+    )]));
+    let mut stream = catalog
+        .query("SELECT COUNT(1) FROM indexlake_inline_index", schema)
+        .await?;
+    let row = futures::TryStreamExt::try_next(&mut stream)
+        .await?
+        .expect("count query returns one row");
+    Ok(row.int64(0)?.expect("count is not null"))
+}
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn update_non_index_column_does_not_affect_indexes(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(BTreeIndexKind));
+
+    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+
+    // Use a catalog-unsupported condition so the inline update path deletes
+    // matched rows and reinserts updated batches.
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut list_builder =
+        ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
+    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.append(true);
+    let scalar = Scalar::List(Arc::new(list_builder.finish()));
+
+    // Update non-index column 'id'
+    let update = TableUpdate {
+        set_map: HashMap::from([("id".to_string(), lit(100i32))]),
+        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
+    };
+    let update_count = table.update(update).await?;
+    assert_eq!(update_count, 1);
+    assert_eq!(count_inline_index_records(catalog).await?, 2);
+
+    // Query via name index - should return exactly 1 row for Alice
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+    ]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query after non-index update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+-----+-------+-----+--------------------+
+| id  | name  | age | vector             |
++-----+-------+-----+--------------------+
+| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
++-----+-------+-----+--------------------+"#
+    );
+
+    // Query via age index - should return exactly 1 row for age=20
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("age index query after non-index update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+-----+-------+-----+--------------------+
+| id  | name  | age | vector             |
++-----+-------+-----+--------------------+
+| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
++-----+-------+-----+--------------------+"#
+    );
+
+    Ok(())
+}
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn update_one_index_column_only_affects_that_index(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(BTreeIndexKind));
+
+    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+
+    // Use a catalog-unsupported condition so the inline update path deletes
+    // matched rows and reinserts updated batches.
+    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let mut list_builder =
+        ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
+    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.append(true);
+    let scalar = Scalar::List(Arc::new(list_builder.finish()));
+
+    // Update indexed column 'name' only
+    let update = TableUpdate {
+        set_map: HashMap::from([(
+            "name".to_string(),
+            lit(Scalar::Utf8(Some("Alicia".to_string()))),
+        )]),
+        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
+    };
+    let update_count = table.update(update).await?;
+    assert_eq!(update_count, 1);
+    assert_eq!(count_inline_index_records(catalog).await?, 2);
+
+    // Query via name index for new name - should return exactly 1 row
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alicia".to_string())))),
+    ]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query for new name after update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+--------+-----+--------------------+
+| id | name   | age | vector             |
++----+--------+-----+--------------------+
+| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
++----+--------+-----+--------------------+"#
+    );
+
+    // Query via name index for old name - should return nothing
+    let scan = TableScan::default().with_filters(vec![
+        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+    ]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("name index query for old name after update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+------+-----+--------+
+| id | name | age | vector |
++----+------+-----+--------+
++----+------+-----+--------+"#
+    );
+
+    // Query via age index - should still work correctly, returning 1 row for age=20
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    let table_str = table_scan(&table, scan).await?;
+    println!("age index query after name update:\n{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+----+--------+-----+--------------------+
+| id | name   | age | vector             |
++----+--------+-----+--------------------+
+| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
++----+--------+-----+--------------------+"#
+    );
+
     Ok(())
 }

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -10,6 +10,7 @@ use indexlake::storage::{DataFileFormat, Storage};
 use indexlake::table::{
     IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate,
 };
+use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use indexlake_integration_tests::data::{
     prepare_simple_testing_table, prepare_simple_vector_table,
 };
@@ -19,7 +20,6 @@ use indexlake_integration_tests::utils::{
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite, init_env_logger, storage_fs, storage_s3,
 };
-use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -1,18 +1,15 @@
-use arrow::array::{Float32Builder, Int32Array, ListBuilder, RecordBatch, StringArray};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{Float32Builder, ListBuilder};
+use arrow::datatypes::{DataType, Field};
 use indexlake::Client;
 use indexlake::catalog::{
     Catalog, CatalogDataType, CatalogSchema, Column, INTERNAL_ROW_ID_FIELD_NAME, Scalar,
 };
 use indexlake::expr::{col, lit};
-use indexlake::index::IndexKind;
 use indexlake::storage::{DataFileFormat, Storage};
-use indexlake::table::{
-    IndexCreation, TableConfig, TableCreation, TableInsertion, TableScan, TableUpdate,
-};
-use indexlake_index_btree::{BTreeIndexKind, BTreeIndexParams};
+use indexlake::table::{TableScan, TableUpdate};
+use indexlake_index_btree::BTreeIndexKind;
 use indexlake_integration_tests::data::{
-    prepare_simple_testing_table, prepare_simple_vector_table,
+    prepare_simple_testing_table, prepare_simple_vector_table, prepare_table_with_two_btree_indexes,
 };
 use indexlake_integration_tests::utils::{
     full_table_scan, read_first_row_id_bytes_from_table, table_scan,
@@ -166,95 +163,6 @@ async fn update_table_by_catalog_unsupported_condition(
     Ok(())
 }
 
-async fn prepare_table_with_two_btree_indexes(
-    client: &Client,
-    format: DataFileFormat,
-) -> Result<(indexlake::table::Table, Arc<dyn Catalog>), Box<dyn std::error::Error>> {
-    let namespace_name = uuid::Uuid::new_v4().to_string();
-    client.create_namespace(&namespace_name, true).await?;
-
-    let table_schema = Arc::new(Schema::new(vec![
-        Field::new("id", DataType::Int32, false),
-        Field::new("name", DataType::Utf8, false),
-        Field::new("age", DataType::Int32, false),
-        Field::new_list(
-            "vector",
-            Arc::new(Field::new("item", DataType::Float32, false)),
-            false,
-        ),
-    ]));
-    // Keep rows inline so inline indexes are used
-    let table_config = TableConfig {
-        inline_row_count_limit: 100,
-        parquet_row_group_size: 2,
-        preferred_data_file_format: format,
-    };
-    let table_name = uuid::Uuid::new_v4().to_string();
-    let table_creation = TableCreation {
-        namespace_name: namespace_name.clone(),
-        table_name: table_name.clone(),
-        schema: table_schema.clone(),
-        config: table_config,
-        ..Default::default()
-    };
-    client.create_table(table_creation).await?;
-    let table = client.load_table(&namespace_name, &table_name).await?;
-
-    let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
-    let mut vector_builder = ListBuilder::new(Float32Builder::new()).with_field(list_inner_field);
-    for vector in [
-        [10.0, 10.0, 10.0],
-        [20.0, 20.0, 20.0],
-        [30.0, 30.0, 30.0],
-        [40.0, 40.0, 40.0],
-    ] {
-        vector_builder.values().append_slice(&vector);
-        vector_builder.append(true);
-    }
-
-    let record_batch = RecordBatch::try_new(
-        table_schema.clone(),
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
-            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
-            Arc::new(Int32Array::from(vec![20, 21, 22, 23])),
-            Arc::new(vector_builder.finish()),
-        ],
-    )?;
-    table
-        .insert(TableInsertion::new(vec![record_batch]))
-        .await?;
-
-    // Create btree index on name
-    let name_index_creation = IndexCreation {
-        name: "name_btree".to_string(),
-        kind: BTreeIndexKind.kind().to_string(),
-        key_columns: vec!["name".to_string()],
-        params: Arc::new(BTreeIndexParams {}),
-        concurrency: 1,
-        if_not_exists: false,
-    };
-    table.create_index(name_index_creation).await?;
-
-    // Reload table after create_index consumes self
-    let table = client.load_table(&namespace_name, &table_name).await?;
-
-    // Create btree index on age
-    let age_index_creation = IndexCreation {
-        name: "age_btree".to_string(),
-        kind: BTreeIndexKind.kind().to_string(),
-        key_columns: vec!["age".to_string()],
-        params: Arc::new(BTreeIndexParams {}),
-        concurrency: 1,
-        if_not_exists: false,
-    };
-    table.create_index(age_index_creation).await?;
-
-    // Reload table after create_index consumes self
-    let table = client.load_table(&namespace_name, &table_name).await?;
-    Ok((table, client.catalog.clone()))
-}
-
 async fn count_inline_index_records(
     catalog: Arc<dyn Catalog>,
     table_id: &Uuid,
@@ -323,7 +231,8 @@ async fn update_non_index_column_does_not_affect_indexes(
     let mut client = Client::new(catalog, storage);
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
-    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let catalog = client.catalog.clone();
     assert_eq!(
         count_inline_index_records(catalog.clone(), &table.table_id).await?,
         2
@@ -400,7 +309,8 @@ async fn update_one_index_column_only_affects_that_index(
     let mut client = Client::new(catalog, storage);
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
-    let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let table = prepare_table_with_two_btree_indexes(&client, format).await?;
+    let catalog = client.catalog.clone();
     assert_eq!(
         count_inline_index_records(catalog.clone(), &table.table_id).await?,
         2

--- a/integration-tests/tests/table_update.rs
+++ b/integration-tests/tests/table_update.rs
@@ -22,6 +22,7 @@ use indexlake_integration_tests::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
+use uuid::Uuid;
 
 #[rstest::rstest]
 #[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
@@ -254,14 +255,48 @@ async fn prepare_table_with_two_btree_indexes(
     Ok((table, client.catalog.clone()))
 }
 
-async fn count_inline_index_records(catalog: Arc<dyn Catalog>) -> indexlake::ILResult<i64> {
+async fn count_inline_index_records(
+    catalog: Arc<dyn Catalog>,
+    table_id: &Uuid,
+) -> indexlake::ILResult<i64> {
     let schema = Arc::new(CatalogSchema::new(vec![Column::new(
+        "index_id",
+        CatalogDataType::Uuid,
+        false,
+    )]));
+    let mut stream = catalog
+        .query(
+            &format!(
+                "SELECT index_id FROM indexlake_index WHERE table_id = {}",
+                catalog.sql_uuid_literal(table_id)
+            ),
+            schema,
+        )
+        .await?;
+    let mut index_ids = Vec::new();
+    while let Some(row) = futures::TryStreamExt::try_next(&mut stream).await? {
+        index_ids.push(row.uuid(0)?.expect("index_id is not null"));
+    }
+    if index_ids.is_empty() {
+        return Ok(0);
+    }
+    let index_id_literals: Vec<String> = index_ids
+        .iter()
+        .map(|id| catalog.sql_uuid_literal(id))
+        .collect();
+    let count_schema = Arc::new(CatalogSchema::new(vec![Column::new(
         "count",
         CatalogDataType::Int64,
         false,
     )]));
     let mut stream = catalog
-        .query("SELECT COUNT(1) FROM indexlake_inline_index", schema)
+        .query(
+            &format!(
+                "SELECT COUNT(1) FROM indexlake_inline_index WHERE index_id IN ({})",
+                index_id_literals.join(", ")
+            ),
+            count_schema,
+        )
         .await?;
     let row = futures::TryStreamExt::try_next(&mut stream)
         .await?
@@ -289,29 +324,35 @@ async fn update_non_index_column_does_not_affect_indexes(
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
     let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
-    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+    assert_eq!(
+        count_inline_index_records(catalog.clone(), &table.table_id).await?,
+        2
+    );
 
-    // Use a catalog-unsupported condition so the inline update path deletes
-    // matched rows and reinserts updated batches.
+    // Use a catalog-unsupported condition (List literal comparison) so the
+    // inline update path deletes matched rows and reinserts updated batches.
     let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
     let mut list_builder =
         ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
-    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.values().append_slice(&[35.0, 35.0, 35.0]);
     list_builder.append(true);
     let scalar = Scalar::List(Arc::new(list_builder.finish()));
 
-    // Update non-index column 'id'
+    // Update non-index column 'id' for the row with vector [40.0, 40.0, 40.0]
     let update = TableUpdate {
         set_map: HashMap::from([("id".to_string(), lit(100i32))]),
-        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
+        condition: col("vector").gt(lit(scalar)),
     };
     let update_count = table.update(update).await?;
     assert_eq!(update_count, 1);
-    assert_eq!(count_inline_index_records(catalog).await?, 2);
+    assert_eq!(
+        count_inline_index_records(catalog, &table.table_id).await?,
+        2
+    );
 
-    // Query via name index - should return exactly 1 row for Alice
+    // Query via name index - should return exactly 1 row for David
     let scan = TableScan::default().with_filters(vec![
-        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+        col("name").eq(lit(Scalar::Utf8(Some("David".to_string())))),
     ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query after non-index update:\n{}", table_str);
@@ -320,12 +361,12 @@ async fn update_non_index_column_does_not_affect_indexes(
         r#"+-----+-------+-----+--------------------+
 | id  | name  | age | vector             |
 +-----+-------+-----+--------------------+
-| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
+| 100 | David | 23  | [40.0, 40.0, 40.0] |
 +-----+-------+-----+--------------------+"#
     );
 
-    // Query via age index - should return exactly 1 row for age=20
-    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    // Query via age index - should return exactly 1 row for age=23
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(23))))]);
     let table_str = table_scan(&table, scan).await?;
     println!("age index query after non-index update:\n{}", table_str);
     assert_eq!(
@@ -333,7 +374,7 @@ async fn update_non_index_column_does_not_affect_indexes(
         r#"+-----+-------+-----+--------------------+
 | id  | name  | age | vector             |
 +-----+-------+-----+--------------------+
-| 100 | Alice | 20  | [10.0, 10.0, 10.0] |
+| 100 | David | 23  | [40.0, 40.0, 40.0] |
 +-----+-------+-----+--------------------+"#
     );
 
@@ -360,32 +401,38 @@ async fn update_one_index_column_only_affects_that_index(
     client.register_index_kind(Arc::new(BTreeIndexKind));
 
     let (table, catalog) = prepare_table_with_two_btree_indexes(&client, format).await?;
-    assert_eq!(count_inline_index_records(catalog.clone()).await?, 2);
+    assert_eq!(
+        count_inline_index_records(catalog.clone(), &table.table_id).await?,
+        2
+    );
 
-    // Use a catalog-unsupported condition so the inline update path deletes
-    // matched rows and reinserts updated batches.
+    // Use a catalog-unsupported condition (List literal comparison) so the
+    // inline update path deletes matched rows and reinserts updated batches.
     let list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
     let mut list_builder =
         ListBuilder::new(Float32Builder::new()).with_field(list_inner_field.clone());
-    list_builder.values().append_slice(&[5.0, 5.0, 5.0]);
+    list_builder.values().append_slice(&[35.0, 35.0, 35.0]);
     list_builder.append(true);
     let scalar = Scalar::List(Arc::new(list_builder.finish()));
 
-    // Update indexed column 'name' only
+    // Update indexed column 'name' only for the row with vector [40.0, 40.0, 40.0]
     let update = TableUpdate {
         set_map: HashMap::from([(
             "name".to_string(),
-            lit(Scalar::Utf8(Some("Alicia".to_string()))),
+            lit(Scalar::Utf8(Some("XDavid".to_string()))),
         )]),
-        condition: col("vector").gt(lit(scalar)).and(col("id").eq(lit(1i32))),
+        condition: col("vector").gt(lit(scalar)),
     };
     let update_count = table.update(update).await?;
     assert_eq!(update_count, 1);
-    assert_eq!(count_inline_index_records(catalog).await?, 2);
+    assert_eq!(
+        count_inline_index_records(catalog, &table.table_id).await?,
+        2
+    );
 
     // Query via name index for new name - should return exactly 1 row
     let scan = TableScan::default().with_filters(vec![
-        col("name").eq(lit(Scalar::Utf8(Some("Alicia".to_string())))),
+        col("name").eq(lit(Scalar::Utf8(Some("XDavid".to_string())))),
     ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query for new name after update:\n{}", table_str);
@@ -394,13 +441,13 @@ async fn update_one_index_column_only_affects_that_index(
         r#"+----+--------+-----+--------------------+
 | id | name   | age | vector             |
 +----+--------+-----+--------------------+
-| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
+| 4  | XDavid | 23  | [40.0, 40.0, 40.0] |
 +----+--------+-----+--------------------+"#
     );
 
     // Query via name index for old name - should return nothing
     let scan = TableScan::default().with_filters(vec![
-        col("name").eq(lit(Scalar::Utf8(Some("Alice".to_string())))),
+        col("name").eq(lit(Scalar::Utf8(Some("David".to_string())))),
     ]);
     let table_str = table_scan(&table, scan).await?;
     println!("name index query for old name after update:\n{}", table_str);
@@ -412,8 +459,8 @@ async fn update_one_index_column_only_affects_that_index(
 +----+------+-----+--------+"#
     );
 
-    // Query via age index - should still work correctly, returning 1 row for age=20
-    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(20))))]);
+    // Query via age index - should still work correctly, returning 1 row for age=23
+    let scan = TableScan::default().with_filters(vec![col("age").eq(lit(Scalar::Int32(Some(23))))]);
     let table_str = table_scan(&table, scan).await?;
     println!("age index query after name update:\n{}", table_str);
     assert_eq!(
@@ -421,7 +468,7 @@ async fn update_one_index_column_only_affects_that_index(
         r#"+----+--------+-----+--------------------+
 | id | name   | age | vector             |
 +----+--------+-----+--------------------+
-| 1  | Alicia | 20  | [10.0, 10.0, 10.0] |
+| 4  | XDavid | 23  | [40.0, 40.0, 40.0] |
 +----+--------+-----+--------------------+"#
     );
 


### PR DESCRIPTION
仅包含：部分索引列更新只重建受影响索引。

**改动内容：**

1. **IndexManager 新增选择性索引方法**
   -  — 根据更新的字段 ID 找出受影响的索引 ID
   -  — 只为指定索引创建 builder

2. **Dump 模块新增 selective rebuild 能力**
   -  — 只删除并重建指定索引
   -  — 只为指定索引构建 inline index records
   -  — 共享构建逻辑，通过工厂闭包创建 builders，flush 后重新创建，保持原始 1000 行分段语义
   -  — 提取重复的 builder flush 逻辑

3. **Insert 模块新增只插行不建索引的函数**
   -  — 用于 update 路径的 delete+insert 分支，避免给所有索引追加脏记录

4. **Update 模块改为 selective rebuild**
   -  中，找到 affected_index_ids 后调用 
   -  非 catalog-filter 分支改用 

5. **回归测试**
   -  — 验证非索引列更新不增加 inline index record 数，两个索引查询结果正确
   -  — 验证只更新 name 索引列时，name 索引返回新值/旧值查不到，age 索引不受污染

**验证结果：**
- ✅ cargo check --lib / --tests 通过
- ✅ cargo test --lib 全部通过（9/9）
- ✅ cargo clippy --lib -- -D warnings 通过

等待 CI 通过后由 @lewiszlw 决定是否合并。