### PR TITLE
feat: unify inline row update to scan + filter + row_id targeted UPDATE

### DIFF
--- a/indexlake/src/catalog/helper/update.rs
+++ b/indexlake/src/catalog/helper/update.rs
@@ -1,8 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
+use arrow::array::ArrayRef;
 use uuid::Uuid;
 
-use crate::catalog::{RowValidity, TransactionHelper, inline_row_table_name};
+use crate::catalog::{
+    INTERNAL_ROW_ID_FIELD_NAME, RowValidity, Scalar, TransactionHelper, inline_row_table_name,
+};
 use crate::expr::Expr;
 use crate::{ILError, ILResult};
 
@@ -72,6 +75,38 @@ impl TransactionHelper {
                 self.catalog.unparse_expr(condition)?
             ))
             .await
+    }
+
+    pub(crate) async fn update_inline_rows_by_row_ids(
+        &mut self,
+        table_id: &Uuid,
+        row_ids: &[Uuid],
+        column_names: &[String],
+        column_arrays: &[ArrayRef],
+    ) -> ILResult<usize> {
+        let mut total_updated = 0;
+        for (i, row_id) in row_ids.iter().enumerate() {
+            let mut set_strs = Vec::new();
+            for (name, array) in column_names.iter().zip(column_arrays.iter()) {
+                let scalar = Scalar::try_from_array(array.as_ref(), i)?;
+                set_strs.push(format!(
+                    "{} = {}",
+                    self.catalog.sql_identifier(name),
+                    scalar.to_sql(self.catalog.as_ref())?
+                ));
+            }
+            total_updated += self
+                .transaction
+                .execute(&format!(
+                    "UPDATE {} SET {} WHERE {} = {}",
+                    inline_row_table_name(table_id),
+                    set_strs.join(", "),
+                    INTERNAL_ROW_ID_FIELD_NAME,
+                    self.catalog.sql_uuid_literal(row_id)
+                ))
+                .await?;
+        }
+        Ok(total_updated)
     }
 
     pub(crate) async fn update_data_file_validity(

--- a/indexlake/src/table/update.rs
+++ b/indexlake/src/table/update.rs
@@ -1,13 +1,17 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use arrow::array::{RecordBatch, RecordBatchOptions};
+use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow::datatypes::Schema;
 use futures::StreamExt;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
-use crate::catalog::{CatalogSchema, DataFileRecord, TransactionHelper, rows_to_record_batch};
-use crate::expr::Expr;
+use crate::catalog::{
+    CatalogSchema, DataFileRecord, INTERNAL_ROW_ID_FIELD_NAME, TransactionHelper,
+    rows_to_record_batch,
+};
+use crate::expr::{Expr, visited_columns};
 use crate::storage::{Storage, read_data_file_by_record, read_row_id_array_from_data_file};
 use crate::table::{
     Table, TableSchemaRef, process_insert_into_inline_rows_with_tx, rebuild_inline_indexes,
@@ -103,43 +107,99 @@ pub(crate) async fn update_inline_rows(
     table: &Table,
     update: &TableUpdate,
 ) -> ILResult<usize> {
-    if tx_helper
-        .catalog
-        .supports_filter(&update.condition, &table.table_schema.arrow_schema)?
-    {
-        tx_helper
-            .update_inline_rows(&table.table_id, &update.set_map, &update.condition)
-            .await
-    } else {
-        let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table.table_schema.arrow_schema)?);
-        let row_stream = tx_helper
-            .scan_inline_rows(&table.table_id, &catalog_schema, &[], None, None)
-            .await?;
-        let mut chunk_stream = row_stream.chunks(100);
-        let mut updated_row_ids = Vec::new();
-        let mut updated_batches = Vec::new();
-        while let Some(row_chunk) = chunk_stream.next().await {
-            let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
-            let record_batch = rows_to_record_batch(&table.table_schema.arrow_schema, &rows)?;
-            let bool_array = update.condition.condition_eval(&record_batch)?;
-            for (i, v) in bool_array.iter().enumerate() {
-                if let Some(v) = v
-                    && v
-                {
-                    updated_row_ids.push(rows[i].uuid(0)?.expect("row_id is not null"));
-                }
-            }
-            let filtered_batch = arrow::compute::filter_record_batch(&record_batch, &bool_array)?;
-            let updated_batch = update_record_batch(&filtered_batch, &update.set_map)?;
-            updated_batches.push(updated_batch);
-        }
-        drop(chunk_stream);
-        tx_helper
-            .delete_inline_rows(&table.table_id, &[], Some(&updated_row_ids))
-            .await?;
-        process_insert_into_inline_rows_with_tx(tx_helper, table, &updated_batches).await?;
-        Ok(updated_row_ids.len())
+    // 1. Build projected schema: only scan columns needed for condition eval,
+    //    update expression eval, and update targets.
+    let mut projection_columns = HashSet::new();
+    projection_columns.insert(INTERNAL_ROW_ID_FIELD_NAME.to_string());
+    projection_columns.extend(visited_columns(&update.condition));
+    for expr in update.set_map.values() {
+        projection_columns.extend(visited_columns(expr));
     }
+    for col_name in update.set_map.keys() {
+        projection_columns.insert(col_name.clone());
+    }
+
+    let projected_fields: Vec<arrow::datatypes::Field> = table
+        .table_schema
+        .arrow_schema
+        .fields()
+        .iter()
+        .filter(|f| projection_columns.contains(f.name()))
+        .map(|f| (**f).clone())
+        .collect();
+    let projected_arrow_schema = Arc::new(Schema::new(projected_fields));
+    let projected_catalog_schema = Arc::new(CatalogSchema::from_arrow(&projected_arrow_schema)?);
+
+    // 2. Scan with projected schema
+    let row_stream = tx_helper
+        .scan_inline_rows(&table.table_id, &projected_catalog_schema, &[], None, None)
+        .await?;
+    let mut chunk_stream = row_stream.chunks(100);
+    let mut matched_batches = Vec::new();
+    while let Some(row_chunk) = chunk_stream.next().await {
+        let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
+        let record_batch = rows_to_record_batch(&projected_arrow_schema, &rows)?;
+        let bool_array = update.condition.condition_eval(&record_batch)?;
+        if bool_array.true_count() > 0 {
+            let filtered_batch = arrow::compute::filter_record_batch(&record_batch, &bool_array)?;
+            matched_batches.push(filtered_batch);
+        }
+    }
+    drop(chunk_stream);
+
+    if matched_batches.is_empty() {
+        return Ok(0);
+    }
+
+    // 3. Evaluate updated values in Arrow
+    let mut updated_batches = Vec::new();
+    for batch in &matched_batches {
+        updated_batches.push(update_record_batch(batch, &update.set_map)?);
+    }
+
+    // 4. Extract row_ids and updated column arrays
+    let mut all_row_ids = Vec::new();
+    let mut column_arrays: HashMap<&str, Vec<ArrayRef>> = HashMap::new();
+    for batch in &updated_batches {
+        let row_id_idx = batch.schema().index_of(INTERNAL_ROW_ID_FIELD_NAME)?;
+        let row_id_array = batch.column(row_id_idx);
+        let fixed_array = row_id_array
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .ok_or_else(|| ILError::internal("Expected FixedSizeBinary row_id column"))?;
+        for i in 0..fixed_array.len() {
+            all_row_ids.push(Uuid::from_slice(fixed_array.value(i))?);
+        }
+        for col_name in update.set_map.keys() {
+            let idx = batch.schema().index_of(col_name)?;
+            column_arrays
+                .entry(col_name.as_str())
+                .or_default()
+                .push(batch.column(idx).clone());
+        }
+    }
+
+    // 5. Concatenate column arrays per column
+    let column_names: Vec<String> = update.set_map.keys().cloned().collect();
+    let mut concatenated_arrays = Vec::new();
+    for col_name in &column_names {
+        let arrays = column_arrays
+            .get(col_name.as_str())
+            .ok_or_else(|| ILError::internal(format!("Missing updated column: {col_name}")))?;
+        let array_refs: Vec<&dyn Array> = arrays.iter().map(|a| a.as_ref()).collect();
+        let concatenated = arrow::compute::concat(&array_refs)?;
+        concatenated_arrays.push(concatenated);
+    }
+
+    // 6. Write back via row_id-targeted UPDATE
+    tx_helper
+        .update_inline_rows_by_row_ids(
+            &table.table_id,
+            &all_row_ids,
+            &column_names,
+            &concatenated_arrays,
+        )
+        .await
 }
 
 pub(crate) async fn update_data_file_rows_by_matched_rows(


### PR DESCRIPTION
统一 inline 行更新路径：去掉 supports_filter 分支，统一走 scan + Arrow filter + row_id 定点 UPDATE。

**改动内容：**

1. **统一  路径**
   - 移除 catalog  分支检查
   - 不再区分 catalog-filter UPDATE 和 delete+insert 两条路径
   - 统一流程：
     1. 扫描所有 inline rows
     2. Arrow filter 判断匹配行
     3. 收集 matched row_ids
     4. 构造  条件
     5. 调用 catalog  按 row_id 定点更新

2. **保持外层 selective rebuild 逻辑**
   -  中  检查和  调用不变

**验证结果：**
- ✅ cargo check --lib / --tests
- ✅ cargo test --lib（9/9）
- ✅ cargo clippy --lib -- -D warnings

等待 CI 通过和 review。