### PR TITLE
refactor: extract flush_index_builders helper

### DIFF
--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -333,17 +333,7 @@ pub(crate) async fn build_all_inline_indexes(
         }
 
         if counter >= 1000 {
-            for index_builder in index_builders.iter_mut() {
-                if index_builder.is_empty() {
-                    continue;
-                }
-                let mut index_data = Vec::new();
-                index_builder.write_bytes(&mut index_data)?;
-                inline_index_records.push(InlineIndexRecord {
-                    index_id: index_builder.index_def().index_id,
-                    index_data,
-                });
-            }
+            flush_index_builders(&mut index_builders, &mut inline_index_records)?;
             counter = 0;
             index_builders = index_manager.new_index_builders()?;
         }
@@ -352,18 +342,26 @@ pub(crate) async fn build_all_inline_indexes(
 
     // build inline index records for left rows
     if counter > 0 {
-        for index_builder in index_builders.iter_mut() {
-            if index_builder.is_empty() {
-                continue;
-            }
-            let mut index_data = Vec::new();
-            index_builder.write_bytes(&mut index_data)?;
-            inline_index_records.push(InlineIndexRecord {
-                index_id: index_builder.index_def().index_id,
-                index_data,
-            });
-        }
+        flush_index_builders(&mut index_builders, &mut inline_index_records)?;
     }
 
     Ok(inline_index_records)
+}
+
+fn flush_index_builders(
+    index_builders: &mut [Box<dyn IndexBuilder>],
+    inline_index_records: &mut Vec<InlineIndexRecord>,
+) -> ILResult<()> {
+    for index_builder in index_builders.iter_mut() {
+        if index_builder.is_empty() {
+            continue;
+        }
+        let mut index_data = Vec::new();
+        index_builder.write_bytes(&mut index_data)?;
+        inline_index_records.push(InlineIndexRecord {
+            index_id: index_builder.index_def().index_id,
+            index_data,
+        });
+    }
+    Ok(())
 }


### PR DESCRIPTION
## 改动

将  中重复的内联索引构建器 flush 逻辑提取为  函数。纯重构，无行为变化。

- 原代码中 counter >= 1000 和 left rows 两段 flush 逻辑完全一致
- 提取为独立 helper 后，后续若有分段语义调整只需改一处

## 验证

- ✅ cargo check --lib / --tests
- ✅ cargo test --lib（38/38 passed）
- ✅ cargo clippy --lib -- -D warnings