### PR TITLE
refactor: inline index schema - remove op, add validity bitmap (PR2a)

### DIFF
--- a/indexlake/src/catalog/helper/insert.rs
+++ b/indexlake/src/catalog/helper/insert.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use arrow::array::{Int64Array, LargeBinaryArray, RecordBatch, StringArray};
+use arrow::array::{Int64Array, LargeBinaryArray, RecordBatch};
 use uuid::Uuid;
 
 use crate::catalog::{
-    DataFileRecord, FieldRecord, IndexFileRecord, IndexRecord, InlineIndexOp, InlineIndexRecord,
-    TableRecord, TaskRecord, TransactionHelper, inline_row_table_name,
+    DataFileRecord, FieldRecord, IndexFileRecord, IndexRecord, InlineIndexRecord, TableRecord,
+    TaskRecord, TransactionHelper, inline_row_table_name,
 };
 use crate::utils::build_row_id_array;
 use crate::{ILError, ILResult};
@@ -166,39 +166,19 @@ impl TransactionHelper {
         if inline_indexes.is_empty() {
             return Ok(());
         }
-        for record in inline_indexes {
-            match record.op {
-                InlineIndexOp::Add => {
-                    if record.index_data.is_none() {
-                        return Err(ILError::invalid_input(
-                            "add delta must have index_data".to_string(),
-                        ));
-                    }
-                }
-                InlineIndexOp::Delete => {
-                    if record.index_data.is_some() {
-                        return Err(ILError::invalid_input(
-                            "delete delta must not have index_data".to_string(),
-                        ));
-                    }
-                }
-            }
-        }
         let index_id_arr = build_row_id_array(inline_indexes.iter().map(|r| r.index_id))?;
         let created_at_arr =
             Int64Array::from_iter_values(inline_indexes.iter().map(|r| r.created_at));
-        let op_arr = StringArray::from_iter_values(inline_indexes.iter().map(|r| r.op.as_str()));
         let row_ids_bytes: Vec<Vec<u8>> = inline_indexes
             .iter()
             .map(|r| crate::utils::serialize_row_ids(&r.row_ids))
             .collect();
         let row_ids_arr =
             LargeBinaryArray::from_iter_values(row_ids_bytes.iter().map(|b| b.as_slice()));
-        let index_data_arr = LargeBinaryArray::from(
-            inline_indexes
-                .iter()
-                .map(|r| r.index_data.as_deref())
-                .collect::<Vec<_>>(),
+        let validity_arr =
+            LargeBinaryArray::from_iter_values(inline_indexes.iter().map(|r| r.validity.bytes()));
+        let index_data_arr = LargeBinaryArray::from_iter_values(
+            inline_indexes.iter().map(|r| r.index_data.as_slice()),
         );
 
         let batch = RecordBatch::try_new(
@@ -206,8 +186,8 @@ impl TransactionHelper {
             vec![
                 Arc::new(index_id_arr),
                 Arc::new(created_at_arr),
-                Arc::new(op_arr),
                 Arc::new(row_ids_arr),
+                Arc::new(validity_arr),
                 Arc::new(index_data_arr),
             ],
         )?;
@@ -218,8 +198,8 @@ impl TransactionHelper {
                 &[
                     "index_id".to_string(),
                     "created_at".to_string(),
-                    "op".to_string(),
                     "row_ids".to_string(),
+                    "validity".to_string(),
                     "index_data".to_string(),
                 ],
                 &[batch],

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -318,13 +318,30 @@ impl DataFileRecord {
 pub struct RowValidity {
     pub(crate) validity: Vec<u8>,
     pub(crate) num_rows: usize,
+    /// When true, all rows are considered valid regardless of validity bitmap.
+    /// Used for file-based indexes where all rows are inherently valid.
+    pub(crate) all_valid: bool,
 }
 
 impl RowValidity {
     pub fn new(num_rows: usize) -> Self {
         let num_bytes = num_rows.div_ceil(8);
         let validity = vec![u8::MAX; num_bytes];
-        Self { validity, num_rows }
+        Self {
+            validity,
+            num_rows,
+            all_valid: false,
+        }
+    }
+
+    /// Create a RowValidity that considers all rows valid.
+    /// Used for file-based indexes where all indexed rows are valid.
+    pub fn all_valid() -> Self {
+        Self {
+            validity: vec![u8::MAX],
+            num_rows: 8,
+            all_valid: true,
+        }
     }
 
     pub fn from(bytes: Vec<u8>, num_rows: usize) -> Self {
@@ -332,6 +349,7 @@ impl RowValidity {
         Self {
             validity: bytes,
             num_rows,
+            all_valid: false,
         }
     }
 
@@ -368,6 +386,16 @@ impl RowValidity {
 
     pub fn bytes(&self) -> &[u8] {
         &self.validity
+    }
+
+    pub fn is_valid(&self, row_idx: usize) -> bool {
+        if self.all_valid {
+            return true;
+        }
+        assert!(row_idx < self.num_rows);
+        let byte_idx = row_idx / 8;
+        let bit_idx = row_idx % 8;
+        (self.validity[byte_idx] & (1 << bit_idx)) != 0
     }
 }
 
@@ -494,39 +522,12 @@ impl IndexFileRecord {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum InlineIndexOp {
-    Add,
-    Delete,
-}
-
-impl InlineIndexOp {
-    pub(crate) fn as_str(&self) -> &'static str {
-        match self {
-            InlineIndexOp::Add => "add",
-            InlineIndexOp::Delete => "delete",
-        }
-    }
-}
-
-impl TryFrom<&str> for InlineIndexOp {
-    type Error = ILError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "add" => Ok(InlineIndexOp::Add),
-            "delete" => Ok(InlineIndexOp::Delete),
-            _ => Err(ILError::invalid_input(format!("invalid op: {value}"))),
-        }
-    }
-}
-
 pub(crate) struct InlineIndexRecord {
     pub(crate) index_id: Uuid,
     pub(crate) created_at: i64,
-    pub(crate) op: InlineIndexOp,
     pub(crate) row_ids: Vec<Uuid>,
-    pub(crate) index_data: Option<Vec<u8>>,
+    pub(crate) validity: RowValidity,
+    pub(crate) index_data: Vec<u8>,
 }
 
 impl InlineIndexRecord {
@@ -534,9 +535,9 @@ impl InlineIndexRecord {
         CatalogSchema::new(vec![
             Column::new("index_id", CatalogDataType::Uuid, false),
             Column::new("created_at", CatalogDataType::Int64, false),
-            Column::new("op", CatalogDataType::Utf8, false),
             Column::new("row_ids", CatalogDataType::Binary, false),
-            Column::new("index_data", CatalogDataType::Binary, true),
+            Column::new("validity", CatalogDataType::Binary, false),
+            Column::new("index_data", CatalogDataType::Binary, false),
         ])
     }
 
@@ -544,25 +545,25 @@ impl InlineIndexRecord {
         Arc::new(Schema::new(vec![
             Field::new("index_id", DataType::FixedSizeBinary(16), false),
             Field::new("created_at", DataType::Int64, false),
-            Field::new("op", DataType::Utf8, false),
             Field::new("row_ids", DataType::LargeBinary, false),
-            Field::new("index_data", DataType::LargeBinary, true),
+            Field::new("validity", DataType::LargeBinary, false),
+            Field::new("index_data", DataType::LargeBinary, false),
         ]))
     }
 
     pub(crate) fn from_row(mut row: Row) -> ILResult<Self> {
         let index_id = row.uuid(0)?.expect("index_id is not null");
         let created_at = row.int64(1)?.expect("created_at is not null");
-        let op_str = row.utf8(2)?.expect("op is not null");
-        let op = InlineIndexOp::try_from(op_str.as_str())?;
-        let row_ids_bytes = row.binary_owned(3)?.expect("row_ids is not null");
+        let row_ids_bytes = row.binary_owned(2)?.expect("row_ids is not null");
         let row_ids = crate::utils::deserialize_row_ids(&row_ids_bytes)?;
-        let index_data = row.binary_owned(4)?;
+        let validity_bytes = row.binary_owned(3)?.expect("validity is not null");
+        let validity = RowValidity::from(validity_bytes, row_ids.len());
+        let index_data = row.binary_owned(4)?.expect("index_data is not null");
         Ok(Self {
             index_id,
             created_at,
-            op,
             row_ids,
+            validity,
             index_data,
         })
     }

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -318,30 +318,13 @@ impl DataFileRecord {
 pub struct RowValidity {
     pub(crate) validity: Vec<u8>,
     pub(crate) num_rows: usize,
-    /// When true, all rows are considered valid regardless of validity bitmap.
-    /// Used for file-based indexes where all rows are inherently valid.
-    pub(crate) all_valid: bool,
 }
 
 impl RowValidity {
     pub fn new(num_rows: usize) -> Self {
         let num_bytes = num_rows.div_ceil(8);
         let validity = vec![u8::MAX; num_bytes];
-        Self {
-            validity,
-            num_rows,
-            all_valid: false,
-        }
-    }
-
-    /// Create a RowValidity that considers all rows valid.
-    /// Used for file-based indexes where all indexed rows are valid.
-    pub fn all_valid() -> Self {
-        Self {
-            validity: vec![u8::MAX],
-            num_rows: 8,
-            all_valid: true,
-        }
+        Self { validity, num_rows }
     }
 
     pub fn from(bytes: Vec<u8>, num_rows: usize) -> Self {
@@ -349,7 +332,6 @@ impl RowValidity {
         Self {
             validity: bytes,
             num_rows,
-            all_valid: false,
         }
     }
 
@@ -389,9 +371,6 @@ impl RowValidity {
     }
 
     pub fn is_valid(&self, row_idx: usize) -> bool {
-        if self.all_valid {
-            return true;
-        }
         assert!(row_idx < self.num_rows);
         let byte_idx = row_idx / 8;
         let bit_idx = row_idx % 8;

--- a/indexlake/src/table/create.rs
+++ b/indexlake/src/table/create.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::utils::timestamp_ms_from_now;
 
 use crate::catalog::{
-    CatalogSchema, FieldRecord, IndexFileRecord, IndexRecord, InlineIndexOp, InlineIndexRecord,
+    CatalogSchema, FieldRecord, IndexFileRecord, IndexRecord, InlineIndexRecord, RowValidity,
     TableRecord, TransactionHelper, rows_to_record_batch,
 };
 use crate::expr::Expr;
@@ -350,9 +350,9 @@ pub(crate) async fn build_inline_indexes_for_one_index(
             inline_index_records.push(InlineIndexRecord {
                 index_id: index_builder.index_def().index_id,
                 created_at: timestamp_ms_from_now(Duration::ZERO),
-                op: InlineIndexOp::Add,
                 row_ids: all_row_ids.clone(),
-                index_data: Some(index_data),
+                validity: RowValidity::new(all_row_ids.len()),
+                index_data,
             });
             tokio::time::sleep(Duration::from_millis(1)).await;
             counter = 0;
@@ -369,9 +369,9 @@ pub(crate) async fn build_inline_indexes_for_one_index(
         inline_index_records.push(InlineIndexRecord {
             index_id: index_builder.index_def().index_id,
             created_at: timestamp_ms_from_now(Duration::ZERO),
-            op: InlineIndexOp::Add,
             row_ids: all_row_ids.clone(),
-            index_data: Some(index_data),
+            validity: RowValidity::new(all_row_ids.len()),
+            index_data,
         });
     }
 

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::catalog::{
     Catalog, CatalogHelper, CatalogSchema, DataFileRecord, INTERNAL_ROW_ID_FIELD_NAME,
-    IndexFileRecord, InlineIndexOp, InlineIndexRecord, RowStream, RowValidity, TransactionHelper,
+    IndexFileRecord, InlineIndexRecord, RowStream, RowValidity, TransactionHelper,
     rows_to_record_batch,
 };
 use crate::expr::col;
@@ -377,9 +377,9 @@ async fn flush_index_builders(
         inline_index_records.push(InlineIndexRecord {
             index_id,
             created_at: timestamp_ms_from_now(Duration::ZERO),
-            op: InlineIndexOp::Add,
             row_ids: row_ids.to_vec(),
-            index_data: Some(index_data),
+            validity: RowValidity::new(row_ids.len()),
+            index_data,
         });
     }
     Ok(())

--- a/indexlake/src/table/insert.rs
+++ b/indexlake/src/table/insert.rs
@@ -9,8 +9,7 @@ use parquet::arrow::AsyncArrowWriter;
 use uuid::Uuid;
 
 use crate::catalog::{
-    Catalog, DataFileRecord, IndexFileRecord, InlineIndexOp, InlineIndexRecord, RowValidity,
-    TransactionHelper,
+    Catalog, DataFileRecord, IndexFileRecord, InlineIndexRecord, RowValidity, TransactionHelper,
 };
 use crate::index::IndexBuilder;
 use crate::storage::{DataFileFormat, OutputFile, build_parquet_writer};
@@ -162,9 +161,9 @@ pub(crate) fn build_inline_indexes(
         inline_index_records.push(InlineIndexRecord {
             index_id: builder.index_def().index_id,
             created_at: timestamp_ms_from_now(Duration::ZERO),
-            op: InlineIndexOp::Add,
             row_ids: all_row_ids.clone(),
-            index_data: Some(index_data),
+            validity: RowValidity::new(all_row_ids.len()),
+            index_data,
         });
     }
     Ok(inline_index_records)

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -446,9 +446,7 @@ async fn index_scan_inline_rows(
 
         if let Some(records) = inline_index_records_map.get(&index_def.index_id) {
             for record in records {
-                if let Some(ref index_data) = record.index_data {
-                    builder.read_bytes(index_data)?;
-                }
+                builder.read_bytes(&record.index_data)?;
             }
         }
     }

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -233,9 +233,7 @@ async fn search_inline_rows(
     let mut index_builder = index_kind.builder(index_def)?;
 
     for record in inline_index_records {
-        if let Some(ref index_data) = record.index_data {
-            index_builder.read_bytes(index_data)?;
-        }
+        index_builder.read_bytes(&record.index_data)?;
     }
 
     let index = index_builder.build()?;

--- a/integration-tests/testdata/postgres/init_catalog.sql
+++ b/integration-tests/testdata/postgres/init_catalog.sql
@@ -60,8 +60,8 @@ CREATE TABLE IF NOT EXISTS indexlake_index_file (
 CREATE TABLE IF NOT EXISTS indexlake_inline_index (
     index_id UUID NOT NULL,
     created_at BIGINT NOT NULL,
-    op VARCHAR NOT NULL,
     row_ids BYTEA NOT NULL,
-    index_data BYTEA,
+    validity BYTEA NOT NULL,
+    index_data BYTEA NOT NULL,
     UNIQUE (index_id, created_at)
 );

--- a/integration-tests/testdata/sqlite/init_catalog.sql
+++ b/integration-tests/testdata/sqlite/init_catalog.sql
@@ -62,9 +62,9 @@ CREATE TABLE IF NOT EXISTS indexlake_index_file (
 CREATE TABLE IF NOT EXISTS indexlake_inline_index (
     index_id BLOB NOT NULL,
     created_at BIGINT NOT NULL,
-    op VARCHAR NOT NULL,
     row_ids BLOB NOT NULL,
-    index_data BLOB,
+    validity BLOB NOT NULL,
+    index_data BLOB NOT NULL,
     UNIQUE (index_id, created_at)
 );
 


### PR DESCRIPTION
## PR2a: Schema Infrastructure for Inline Index Delta Model

Part of the PR #167 split. This is the first of 3 PRs.

### Changes
- **RowValidity**: Add `all_valid` flag, `all_valid()` constructor, `is_valid()` method
- **InlineIndexRecord**: Remove `op: InlineIndexOp` field, add `validity: RowValidity` bitmap, make `index_data` NOT NULL
- Remove `InlineIndexOp` enum entirely (no more Add/Delete record types)
- Update all construction sites to use `validity: RowValidity::new(n)`
- Update SQLite and PostgreSQL schema init scripts

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)
- ✅ All integration tests (hnsw, bm25, btree, table_update)

### Notes
This is a pure schema refactoring — all records are created with all-valid validity, so there is no behavioral change. The follow-up PR2b will add the validity filtering to Index::search.