### PR TITLE
feat: add validity parameter to Index::search and read path (PR2b)

### DIFF
--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -49,7 +49,7 @@ impl Index for BM25Index {
         let query_embedding = self.embedder.embed(&query.query);
         let matches = self
             .scorer
-            .matches(&query_embedding, query.limit, Some(validity))?;
+            .matches(&query_embedding, query.limit, validity)?;
 
         let mut row_ids = Vec::with_capacity(matches.len());
         let mut scores = Vec::with_capacity(matches.len());

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -37,6 +37,10 @@ pub struct BM25Index {
 
 #[async_trait::async_trait]
 impl Index for BM25Index {
+    fn num_rows(&self) -> usize {
+        self.scorer.num_rows()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -5,7 +5,8 @@ use arrow::datatypes::{DataType, Field};
 use bm25::Embedder;
 use indexlake::expr::Expr;
 use indexlake::index::{
-    DynamicColumn, FilterIndexEntries, Index, IndexDefinitionRef, SearchIndexEntries, SearchQuery,
+    DynamicColumn, FilterIndexEntries, Index, IndexDefinitionRef, RowValidity, SearchIndexEntries,
+    SearchQuery,
 };
 use indexlake::{ILError, ILResult};
 
@@ -40,12 +41,15 @@ impl Index for BM25Index {
         &self,
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
+        validity: &RowValidity,
     ) -> ILResult<SearchIndexEntries> {
         let query = query
             .downcast_ref::<BM25SearchQuery>()
             .ok_or(ILError::index("Invalid query type"))?;
         let query_embedding = self.embedder.embed(&query.query);
-        let matches = self.scorer.matches(&query_embedding, query.limit)?;
+        let matches = self
+            .scorer
+            .matches(&query_embedding, query.limit, Some(validity))?;
 
         let mut row_ids = Vec::with_capacity(matches.len());
         let mut scores = Vec::with_capacity(matches.len());

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -37,10 +37,6 @@ pub struct BM25Index {
 
 #[async_trait::async_trait]
 impl Index for BM25Index {
-    fn num_rows(&self) -> usize {
-        self.scorer.num_rows()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/bm25/src/scorer.rs
+++ b/indexes/bm25/src/scorer.rs
@@ -265,7 +265,7 @@ impl ArrowScorer {
         &self,
         query_embedding: &Embedding<u32>,
         limit: Option<usize>,
-        validity: Option<&indexlake::index::RowValidity>,
+        validity: &indexlake::index::RowValidity,
     ) -> ILResult<Vec<ScoredDocument<Uuid>>> {
         if self.row_ids.is_empty() || matches!(limit, Some(0)) {
             return Ok(Vec::new());
@@ -297,9 +297,7 @@ impl ArrowScorer {
         let mut scores = Vec::new();
         for (doc_id, &score) in scores_by_doc_id.iter().enumerate() {
             if score > 0.0 {
-                if let Some(validity) = validity
-                    && !validity.is_valid(doc_id)
-                {
+                if !validity.is_valid(doc_id) {
                     continue;
                 }
                 scores.push(ScoredDocument {

--- a/indexes/bm25/src/scorer.rs
+++ b/indexes/bm25/src/scorer.rs
@@ -261,6 +261,7 @@ impl ArrowScorer {
         &self,
         query_embedding: &Embedding<u32>,
         limit: Option<usize>,
+        validity: Option<&indexlake::index::RowValidity>,
     ) -> ILResult<Vec<ScoredDocument<Uuid>>> {
         if self.row_ids.is_empty() || matches!(limit, Some(0)) {
             return Ok(Vec::new());
@@ -292,6 +293,11 @@ impl ArrowScorer {
         let mut scores = Vec::new();
         for (doc_id, &score) in scores_by_doc_id.iter().enumerate() {
             if score > 0.0 {
+                if let Some(validity) = validity
+                    && !validity.is_valid(doc_id)
+                {
+                    continue;
+                }
                 scores.push(ScoredDocument {
                     id: self.row_ids[doc_id],
                     score,

--- a/indexes/bm25/src/scorer.rs
+++ b/indexes/bm25/src/scorer.rs
@@ -80,6 +80,10 @@ struct Posting {
 }
 
 impl ArrowScorer {
+    pub fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.row_ids.is_empty()
     }

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -114,6 +114,7 @@ impl Index for BTreeIndex {
         &self,
         _query: &dyn SearchQuery,
         _dynamic_fields: &[String],
+        _validity: &indexlake::index::RowValidity,
     ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "B-tree index does not support search",

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -110,10 +110,6 @@ impl BTreeIndex {
 
 #[async_trait::async_trait]
 impl Index for BTreeIndex {
-    fn num_rows(&self) -> usize {
-        self.btree.values().map(|v| v.len()).sum()
-    }
-
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -110,6 +110,10 @@ impl BTreeIndex {
 
 #[async_trait::async_trait]
 impl Index for BTreeIndex {
+    fn num_rows(&self) -> usize {
+        self.btree.values().map(|v| v.len()).sum()
+    }
+
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -49,6 +49,10 @@ impl std::fmt::Debug for HnswIndex {
 
 #[async_trait::async_trait]
 impl Index for HnswIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -4,7 +4,9 @@ use arrow::array::Float64Array;
 use arrow::datatypes::{DataType, Field};
 use hnsw::Hnsw;
 use indexlake::expr::Expr;
-use indexlake::index::{DynamicColumn, FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{
+    DynamicColumn, FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery,
+};
 use indexlake::{ILError, ILResult};
 use rand_pcg::Pcg64;
 use space::Knn;
@@ -51,6 +53,7 @@ impl Index for HnswIndex {
         &self,
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
+        validity: &RowValidity,
     ) -> ILResult<SearchIndexEntries> {
         let query = query.downcast_ref::<HnswSearchQuery>().ok_or_else(|| {
             ILError::index(format!(
@@ -58,14 +61,28 @@ impl Index for HnswIndex {
             ))
         })?;
 
-        let limit = std::cmp::min(query.limit, self.hnsw.len());
-
-        let neighbors = self.hnsw.knn(&query.vector, limit);
-        let mut row_ids = Vec::with_capacity(neighbors.len());
-        let mut scores = Vec::with_capacity(neighbors.len());
-        for neighbor in neighbors {
-            row_ids.push(self.row_ids[neighbor.index]);
-            scores.push(neighbor.distance as f64);
+        // Keep fetching until we get enough valid rows or exhaust the index
+        let mut row_ids = Vec::new();
+        let mut scores = Vec::new();
+        let total = self.hnsw.len();
+        let mut fetch_limit = query.limit.min(total);
+        let mut scanned_count = 0;
+        while row_ids.len() < query.limit && fetch_limit <= total {
+            let neighbors = self.hnsw.knn(&query.vector, fetch_limit);
+            for neighbor in &neighbors[scanned_count..] {
+                if validity.is_valid(neighbor.index) {
+                    row_ids.push(self.row_ids[neighbor.index]);
+                    scores.push(neighbor.distance as f64);
+                    if row_ids.len() >= query.limit {
+                        break;
+                    }
+                }
+            }
+            scanned_count = neighbors.len();
+            if fetch_limit >= total {
+                break;
+            }
+            fetch_limit = (fetch_limit * 2).min(total);
         }
 
         let mut dynamic_columns = Vec::with_capacity(dynamic_fields.len());

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -49,10 +49,6 @@ impl std::fmt::Debug for HnswIndex {
 
 #[async_trait::async_trait]
 impl Index for HnswIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -50,10 +50,6 @@ impl std::fmt::Debug for RabitqIndex {
 
 #[async_trait::async_trait]
 impl Index for RabitqIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -50,6 +50,10 @@ impl std::fmt::Debug for RabitqIndex {
 
 #[async_trait::async_trait]
 impl Index for RabitqIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use arrow::array::Float64Array;
 use arrow::datatypes::{DataType, Field};
 use indexlake::expr::Expr;
-use indexlake::index::{DynamicColumn, FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{
+    DynamicColumn, FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery,
+};
 use indexlake::{ILError, ILResult};
 use uuid::Uuid;
 
@@ -52,6 +54,7 @@ impl Index for RabitqIndex {
         &self,
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
+        validity: &RowValidity,
     ) -> ILResult<SearchIndexEntries> {
         let query = query.downcast_ref::<RabitqSearchQuery>().ok_or_else(|| {
             ILError::index(format!(
@@ -61,15 +64,33 @@ impl Index for RabitqIndex {
 
         let score_higher_is_better = matches!(self.metric, RabitqMetric::InnerProduct);
 
-        let params = BruteForceSearchParams { top_k: query.limit };
-        let results = self
-            .inner
-            .search(&query.vector, params)
-            .map_err(|e| ILError::index(format!("RaBitQ brute force search failed: {e}")))?;
-        let (row_ids, scores): (Vec<Uuid>, Vec<f64>) = results
-            .into_iter()
-            .map(|r| (self.row_ids[r.id], r.score as f64))
-            .unzip();
+        // Keep fetching until we get enough valid rows or exhaust the index
+        let mut row_ids = Vec::new();
+        let mut scores = Vec::new();
+        let total_vectors = self.row_ids.len();
+        let mut fetch_limit = query.limit.min(total_vectors);
+        let mut scanned_count = 0;
+        while row_ids.len() < query.limit && fetch_limit <= total_vectors {
+            let params = BruteForceSearchParams { top_k: fetch_limit };
+            let results = self
+                .inner
+                .search(&query.vector, params)
+                .map_err(|e| ILError::index(format!("RaBitQ brute force search failed: {e}")))?;
+            for r in &results[scanned_count..] {
+                if validity.is_valid(r.id) {
+                    row_ids.push(self.row_ids[r.id]);
+                    scores.push(r.score as f64);
+                    if row_ids.len() >= query.limit {
+                        break;
+                    }
+                }
+            }
+            scanned_count = results.len();
+            if fetch_limit >= total_vectors {
+                break;
+            }
+            fetch_limit = (fetch_limit * 2).min(total_vectors);
+        }
 
         let mut dynamic_columns = Vec::with_capacity(dynamic_fields.len());
         for dynamic_field in dynamic_fields {

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -31,6 +31,10 @@ pub struct RStarIndex {
 
 #[async_trait::async_trait]
 impl Index for RStarIndex {
+    fn num_rows(&self) -> usize {
+        self.rtree.size()
+    }
+
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -31,10 +31,6 @@ pub struct RStarIndex {
 
 #[async_trait::async_trait]
 impl Index for RStarIndex {
-    fn num_rows(&self) -> usize {
-        self.rtree.size()
-    }
-
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -35,6 +35,7 @@ impl Index for RStarIndex {
         &self,
         _query: &dyn SearchQuery,
         _dynamic_fields: &[String],
+        _validity: &indexlake::index::RowValidity,
     ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "RStar index does not support search",

--- a/indexlake/src/catalog/helper/insert.rs
+++ b/indexlake/src/catalog/helper/insert.rs
@@ -175,8 +175,12 @@ impl TransactionHelper {
             .collect();
         let row_ids_arr =
             LargeBinaryArray::from_iter_values(row_ids_bytes.iter().map(|b| b.as_slice()));
+        let validity_bytes: Vec<Vec<u8>> = inline_indexes
+            .iter()
+            .map(|r| r.validity.bytes().to_vec())
+            .collect();
         let validity_arr =
-            LargeBinaryArray::from_iter_values(inline_indexes.iter().map(|r| r.validity.bytes()));
+            LargeBinaryArray::from_iter_values(validity_bytes.iter().map(|b| b.as_slice()));
         let index_data_arr = LargeBinaryArray::from_iter_values(
             inline_indexes.iter().map(|r| r.index_data.as_slice()),
         );

--- a/indexlake/src/catalog/helper/query.rs
+++ b/indexlake/src/catalog/helper/query.rs
@@ -603,7 +603,7 @@ impl CatalogHelper {
         let rows = self
             .query_rows(
                 &format!(
-                    "SELECT {} FROM indexlake_inline_index WHERE index_id IN ({})",
+                    "SELECT {} FROM indexlake_inline_index WHERE index_id IN ({}) ORDER BY created_at ASC",
                     schema.select_items(self.catalog.as_ref()).join(", "),
                     index_ids
                         .iter()

--- a/indexlake/src/catalog/helper/update.rs
+++ b/indexlake/src/catalog/helper/update.rs
@@ -4,7 +4,8 @@ use arrow::array::ArrayRef;
 use uuid::Uuid;
 
 use crate::catalog::{
-    INTERNAL_ROW_ID_FIELD_NAME, RowValidity, Scalar, TransactionHelper, inline_row_table_name,
+    INTERNAL_ROW_ID_FIELD_NAME, InlineIndexRecord, RowValidity, Scalar, TransactionHelper,
+    inline_row_table_name,
 };
 use crate::expr::Expr;
 use crate::{ILError, ILResult};
@@ -156,5 +157,61 @@ impl TransactionHelper {
 
         self.update_data_file_validity(data_file_id, &old_validity, &validity)
             .await
+    }
+
+    /// Mark specific row_ids as invalid in inline index segments.
+    /// Returns the number of segments updated.
+    pub(crate) async fn invalidate_inline_index_rows(
+        &mut self,
+        index_id: &Uuid,
+        invalid_row_ids: &HashSet<Uuid>,
+    ) -> ILResult<usize> {
+        if invalid_row_ids.is_empty() {
+            return Ok(0);
+        }
+
+        // Fetch all inline index records for this index
+        let schema = std::sync::Arc::new(InlineIndexRecord::catalog_schema());
+        let rows = self
+            .query_rows(
+                &format!(
+                    "SELECT {} FROM indexlake_inline_index WHERE index_id = {} ORDER BY created_at ASC",
+                    schema.select_items(self.catalog.as_ref()).join(", "),
+                    self.catalog.sql_uuid_literal(index_id),
+                ),
+                schema,
+            )
+            .await?;
+
+        let mut updated_count = 0;
+
+        for row in rows {
+            let record = InlineIndexRecord::from_row(row)?;
+            let mut modified = false;
+            let mut validity = record.validity.clone();
+
+            for (i, row_id) in record.row_ids.iter().enumerate() {
+                if invalid_row_ids.contains(row_id) && validity.is_valid(i) {
+                    validity.set(i, false);
+                    modified = true;
+                }
+            }
+
+            if modified {
+                // Update the record in the database
+                let update_count = self
+                    .transaction
+                    .execute(&format!(
+                        "UPDATE indexlake_inline_index SET validity = {} WHERE index_id = {} AND created_at = {}",
+                        self.catalog.sql_binary_literal(validity.bytes()),
+                        self.catalog.sql_uuid_literal(&record.index_id),
+                        record.created_at,
+                    ))
+                    .await?;
+                updated_count += update_count;
+            }
+        }
+
+        Ok(updated_count)
     }
 }

--- a/indexlake/src/catalog/helper/update.rs
+++ b/indexlake/src/catalog/helper/update.rs
@@ -4,8 +4,8 @@ use arrow::array::ArrayRef;
 use uuid::Uuid;
 
 use crate::catalog::{
-    INTERNAL_ROW_ID_FIELD_NAME, InlineIndexRecord, RowValidity, Scalar, TransactionHelper,
-    inline_row_table_name,
+    CatalogDataType, CatalogSchema, Column, INTERNAL_ROW_ID_FIELD_NAME, RowValidity, Scalar,
+    TransactionHelper, inline_row_table_name,
 };
 use crate::expr::Expr;
 use crate::{ILError, ILResult};
@@ -170,13 +170,17 @@ impl TransactionHelper {
             return Ok(0);
         }
 
-        // Fetch all inline index records for this index
-        let schema = std::sync::Arc::new(InlineIndexRecord::catalog_schema());
+        // Fetch only the columns we need to invalidate rows
+        let schema = std::sync::Arc::new(CatalogSchema::new(vec![
+            Column::new("index_id", CatalogDataType::Uuid, false),
+            Column::new("created_at", CatalogDataType::Int64, false),
+            Column::new("row_ids", CatalogDataType::Binary, false),
+            Column::new("validity", CatalogDataType::Binary, false),
+        ]));
         let rows = self
             .query_rows(
                 &format!(
-                    "SELECT {} FROM indexlake_inline_index WHERE index_id = {} ORDER BY created_at ASC",
-                    schema.select_items(self.catalog.as_ref()).join(", "),
+                    "SELECT index_id, created_at, row_ids, validity FROM indexlake_inline_index WHERE index_id = {} ORDER BY created_at ASC",
                     self.catalog.sql_uuid_literal(index_id),
                 ),
                 schema,
@@ -185,12 +189,16 @@ impl TransactionHelper {
 
         let mut updated_count = 0;
 
-        for row in rows {
-            let record = InlineIndexRecord::from_row(row)?;
+        for mut row in rows {
+            let idx_id = row.uuid(0)?.expect("index_id is not null");
+            let idx_created_at = row.int64(1)?.expect("created_at is not null");
+            let row_ids_bytes = row.binary_owned(2)?.expect("row_ids is not null");
+            let row_ids = crate::utils::deserialize_row_ids(&row_ids_bytes)?;
+            let validity_bytes = row.binary_owned(3)?.expect("validity is not null");
+            let mut validity = RowValidity::from(validity_bytes, row_ids.len());
             let mut modified = false;
-            let mut validity = record.validity.clone();
 
-            for (i, row_id) in record.row_ids.iter().enumerate() {
+            for (i, row_id) in row_ids.iter().enumerate() {
                 if invalid_row_ids.contains(row_id) && validity.is_valid(i) {
                     validity.set(i, false);
                     modified = true;
@@ -204,8 +212,8 @@ impl TransactionHelper {
                     .execute(&format!(
                         "UPDATE indexlake_inline_index SET validity = {} WHERE index_id = {} AND created_at = {}",
                         self.catalog.sql_binary_literal(validity.bytes()),
-                        self.catalog.sql_uuid_literal(&record.index_id),
-                        record.created_at,
+                        self.catalog.sql_uuid_literal(&idx_id),
+                        idx_created_at,
                     ))
                     .await?;
                 updated_count += update_count;

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -318,13 +318,30 @@ impl DataFileRecord {
 pub struct RowValidity {
     pub(crate) validity: Vec<u8>,
     pub(crate) num_rows: usize,
+    /// When true, all rows are considered valid regardless of validity bitmap.
+    /// Used for file-based indexes where all rows are inherently valid.
+    pub(crate) all_valid: bool,
 }
 
 impl RowValidity {
     pub fn new(num_rows: usize) -> Self {
         let num_bytes = num_rows.div_ceil(8);
         let validity = vec![u8::MAX; num_bytes];
-        Self { validity, num_rows }
+        Self {
+            validity,
+            num_rows,
+            all_valid: false,
+        }
+    }
+
+    /// Create a RowValidity that considers all rows valid.
+    /// Used for file-based indexes where all indexed rows are valid.
+    pub fn all_valid() -> Self {
+        Self {
+            validity: vec![u8::MAX],
+            num_rows: 8,
+            all_valid: true,
+        }
     }
 
     pub fn from(bytes: Vec<u8>, num_rows: usize) -> Self {
@@ -332,6 +349,7 @@ impl RowValidity {
         Self {
             validity: bytes,
             num_rows,
+            all_valid: false,
         }
     }
 
@@ -371,6 +389,9 @@ impl RowValidity {
     }
 
     pub fn is_valid(&self, row_idx: usize) -> bool {
+        if self.all_valid {
+            return true;
+        }
         assert!(row_idx < self.num_rows);
         let byte_idx = row_idx / 8;
         let bit_idx = row_idx % 8;

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -318,30 +318,13 @@ impl DataFileRecord {
 pub struct RowValidity {
     pub(crate) validity: Vec<u8>,
     pub(crate) num_rows: usize,
-    /// When true, all rows are considered valid regardless of validity bitmap.
-    /// Used for file-based indexes where all rows are inherently valid.
-    pub(crate) all_valid: bool,
 }
 
 impl RowValidity {
     pub fn new(num_rows: usize) -> Self {
         let num_bytes = num_rows.div_ceil(8);
         let validity = vec![u8::MAX; num_bytes];
-        Self {
-            validity,
-            num_rows,
-            all_valid: false,
-        }
-    }
-
-    /// Create a RowValidity that considers all rows valid.
-    /// Used for file-based indexes where all indexed rows are valid.
-    pub fn all_valid() -> Self {
-        Self {
-            validity: vec![u8::MAX],
-            num_rows: 8,
-            all_valid: true,
-        }
+        Self { validity, num_rows }
     }
 
     pub fn from(bytes: Vec<u8>, num_rows: usize) -> Self {
@@ -349,7 +332,6 @@ impl RowValidity {
         Self {
             validity: bytes,
             num_rows,
-            all_valid: false,
         }
     }
 
@@ -389,9 +371,6 @@ impl RowValidity {
     }
 
     pub fn is_valid(&self, row_idx: usize) -> bool {
-        if self.all_valid {
-            return true;
-        }
         assert!(row_idx < self.num_rows);
         let byte_idx = row_idx / 8;
         let bit_idx = row_idx % 8;

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -61,6 +61,9 @@ pub trait IndexBuilder: Debug + Send + Sync {
 
 #[async_trait::async_trait]
 pub trait Index: Debug + Send + Sync {
+    /// Returns the number of rows indexed.
+    fn num_rows(&self) -> usize;
+
     /// Search the index.
     /// `validity` indicates which rows in the index are valid (not deleted/updated).
     async fn search(

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -61,11 +61,10 @@ pub trait IndexBuilder: Debug + Send + Sync {
 
 #[async_trait::async_trait]
 pub trait Index: Debug + Send + Sync {
-    /// Returns the number of rows indexed.
-    fn num_rows(&self) -> usize;
-
     /// Search the index.
-    /// `validity` indicates which rows in the index are valid (not deleted/updated).
+    /// `validity` indicates which rows in the index are valid.
+    /// Index implementations must filter out invalid rows internally
+    /// so that they do not occupy result slots.
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -6,6 +6,7 @@ pub use manager::*;
 use uuid::Uuid;
 
 use crate::ILResult;
+pub use crate::catalog::RowValidity;
 use crate::expr::Expr;
 use crate::storage::{InputFile, OutputFile};
 use arrow::array::{ArrayRef, RecordBatch};
@@ -60,10 +61,13 @@ pub trait IndexBuilder: Debug + Send + Sync {
 
 #[async_trait::async_trait]
 pub trait Index: Debug + Send + Sync {
+    /// Search the index.
+    /// `validity` indicates which rows in the index are valid (not deleted/updated).
     async fn search(
         &self,
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
+        validity: &RowValidity,
     ) -> ILResult<SearchIndexEntries>;
 
     async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries>;

--- a/indexlake/src/table/delete.rs
+++ b/indexlake/src/table/delete.rs
@@ -25,9 +25,19 @@ pub(crate) async fn process_delete_by_condition(
     condition: &Expr,
     matched_data_file_row_ids: HashMap<Uuid, HashSet<Uuid>>,
 ) -> ILResult<usize> {
-    // Directly delete inline rows
-    let inline_delete_count =
+    // Directly delete inline rows and collect deleted row_ids
+    let (inline_delete_count, deleted_row_ids) =
         delete_inline_rows(tx_helper, &table.table_id, &table.table_schema, condition).await?;
+
+    // Invalidate deleted rows in all inline indexes
+    if !deleted_row_ids.is_empty() {
+        let deleted_row_ids_set: HashSet<Uuid> = deleted_row_ids.into_iter().collect();
+        for index_id in table.index_manager.index_ids() {
+            tx_helper
+                .invalidate_inline_index_rows(&index_id, &deleted_row_ids_set)
+                .await?;
+        }
+    }
 
     let data_file_records = tx_helper.get_data_files(&table.table_id).await?;
 
@@ -74,39 +84,31 @@ pub(crate) async fn delete_inline_rows(
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     condition: &Expr,
-) -> ILResult<usize> {
+) -> ILResult<(usize, Vec<Uuid>)> {
     // TODO improve performance through projection
-    if tx_helper
-        .catalog
-        .supports_filter(condition, &table_schema.arrow_schema)?
-    {
-        tx_helper
-            .delete_inline_rows(table_id, std::slice::from_ref(condition), None)
-            .await
-    } else {
-        let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
-        let row_stream = tx_helper
-            .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
-            .await?;
-        let mut chunk_stream = row_stream.chunks(100);
-        let mut matched_row_ids = Vec::new();
-        while let Some(row_chunk) = chunk_stream.next().await {
-            let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
-            let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
-            let bool_array = condition.condition_eval(&record_batch)?;
-            for (i, v) in bool_array.iter().enumerate() {
-                if let Some(v) = v
-                    && v
-                {
-                    matched_row_ids.push(rows[i].uuid(0)?.expect("row_id is not null"));
-                }
+    let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
+    let row_stream = tx_helper
+        .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
+        .await?;
+    let mut chunk_stream = row_stream.chunks(100);
+    let mut matched_row_ids = Vec::new();
+    while let Some(row_chunk) = chunk_stream.next().await {
+        let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
+        let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
+        let bool_array = condition.condition_eval(&record_batch)?;
+        for (i, v) in bool_array.iter().enumerate() {
+            if let Some(v) = v
+                && v
+            {
+                matched_row_ids.push(rows[i].uuid(0)?.expect("row_id is not null"));
             }
         }
-        drop(chunk_stream);
-        tx_helper
-            .delete_inline_rows(table_id, &[], Some(matched_row_ids.as_slice()))
-            .await
     }
+    drop(chunk_stream);
+    let count = tx_helper
+        .delete_inline_rows(table_id, &[], Some(matched_row_ids.as_slice()))
+        .await?;
+    Ok((count, matched_row_ids))
 }
 
 pub(crate) async fn delete_data_file_rows_by_condition(
@@ -140,13 +142,23 @@ pub(crate) async fn process_delete_by_row_id_condition(
     table: &Table,
     row_id_condition: &Expr,
 ) -> ILResult<usize> {
-    let inline_delete_count = delete_inline_rows(
+    let (inline_delete_count, deleted_row_ids) = delete_inline_rows(
         tx_helper,
         &table.table_id,
         &table.table_schema,
         row_id_condition,
     )
     .await?;
+
+    // Invalidate deleted rows in all inline indexes
+    if !deleted_row_ids.is_empty() {
+        let deleted_row_ids_set: HashSet<Uuid> = deleted_row_ids.into_iter().collect();
+        for index_id in table.index_manager.index_ids() {
+            tx_helper
+                .invalidate_inline_index_rows(&index_id, &deleted_row_ids_set)
+                .await?;
+        }
+    }
 
     let data_file_records = tx_helper.get_data_files(&table.table_id).await?;
 

--- a/indexlake/src/table/delete.rs
+++ b/indexlake/src/table/delete.rs
@@ -26,8 +26,10 @@ pub(crate) async fn process_delete_by_condition(
     matched_data_file_row_ids: HashMap<Uuid, HashSet<Uuid>>,
 ) -> ILResult<usize> {
     // Directly delete inline rows and collect deleted row_ids
-    let (inline_delete_count, deleted_row_ids) =
+    let deleted_row_ids =
         delete_inline_rows(tx_helper, &table.table_id, &table.table_schema, condition).await?;
+
+    let inline_delete_count = deleted_row_ids.len();
 
     // Invalidate deleted rows in all inline indexes
     if !deleted_row_ids.is_empty() {
@@ -84,7 +86,7 @@ pub(crate) async fn delete_inline_rows(
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     condition: &Expr,
-) -> ILResult<(usize, Vec<Uuid>)> {
+) -> ILResult<Vec<Uuid>> {
     // TODO improve performance through projection
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
@@ -105,10 +107,10 @@ pub(crate) async fn delete_inline_rows(
         }
     }
     drop(chunk_stream);
-    let count = tx_helper
+    tx_helper
         .delete_inline_rows(table_id, &[], Some(matched_row_ids.as_slice()))
         .await?;
-    Ok((count, matched_row_ids))
+    Ok(matched_row_ids)
 }
 
 pub(crate) async fn delete_data_file_rows_by_condition(
@@ -142,13 +144,15 @@ pub(crate) async fn process_delete_by_row_id_condition(
     table: &Table,
     row_id_condition: &Expr,
 ) -> ILResult<usize> {
-    let (inline_delete_count, deleted_row_ids) = delete_inline_rows(
+    let deleted_row_ids = delete_inline_rows(
         tx_helper,
         &table.table_id,
         &table.table_schema,
         row_id_condition,
     )
     .await?;
+
+    let inline_delete_count = deleted_row_ids.len();
 
     // Invalidate deleted rows in all inline indexes
     if !deleted_row_ids.is_empty() {

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -374,11 +374,12 @@ async fn flush_index_builders(
         let mut index_data = Vec::new();
         index_builder.write_bytes(&mut index_data)?;
         let index_id = index_builder.index_def().index_id;
+        let row_ids_vec = row_ids.to_vec();
         inline_index_records.push(InlineIndexRecord {
             index_id,
             created_at: timestamp_ms_from_now(Duration::ZERO),
-            row_ids: row_ids.to_vec(),
-            validity: RowValidity::new(row_ids.len()),
+            row_ids: row_ids_vec.clone(),
+            validity: RowValidity::new(row_ids_vec.len()),
             index_data,
         });
     }

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -16,7 +16,7 @@ use crate::catalog::{
     rows_to_record_batch,
 };
 use crate::expr::{Expr, merge_filters, row_ids_in_list_expr, split_conjunction_filters};
-use crate::index::{FilterSupport, IndexManager};
+use crate::index::{FilterIndexEntries, FilterSupport, IndexManager};
 use crate::storage::{Storage, count_data_file_by_record, read_data_file_by_record};
 use crate::table::{Table, TableSchemaRef};
 use crate::utils::project_schema;
@@ -412,9 +412,28 @@ async fn index_scan_inline_rows(
     index_filter_assignment: &HashMap<String, Vec<usize>>,
     non_index_filters: &[Expr],
 ) -> ILResult<RecordBatchStream> {
-    let mut index_builder_map = HashMap::new();
     let mut index_ids = Vec::new();
     for (index_name, _) in index_filter_assignment.iter() {
+        let index_def = table
+            .index_manager
+            .get_index(index_name)
+            .ok_or_else(|| ILError::internal(format!("Index {index_name} not found")))?;
+        index_ids.push(index_def.index_id);
+    }
+
+    // read inline index records ordered by created_at
+    let inline_index_records = catalog_helper.get_inline_indexes(&index_ids).await?;
+    let mut inline_index_records_map: HashMap<Uuid, Vec<InlineIndexRecord>> = HashMap::new();
+    for record in inline_index_records {
+        inline_index_records_map
+            .entry(record.index_id)
+            .or_default()
+            .push(record);
+    }
+
+    // filter row ids by indexes, per segment
+    let mut filter_index_entries_list: Vec<FilterIndexEntries> = Vec::new();
+    for (index_name, filter_indices) in index_filter_assignment.iter() {
         let index_def = table
             .index_manager
             .get_index(index_name)
@@ -425,48 +444,41 @@ async fn index_scan_inline_rows(
             .get_index_kind(kind)
             .ok_or_else(|| ILError::internal(format!("Index kind {kind} not registered")))?;
 
-        let index_builder = index_kind.builder(index_def)?;
-        index_builder_map.insert(index_name, index_builder);
-        index_ids.push(index_def.index_id);
-    }
-
-    // read inline index records
-    let inline_index_records = catalog_helper.get_inline_indexes(&index_ids).await?;
-    let mut inline_index_records_map: HashMap<Uuid, Vec<InlineIndexRecord>> = HashMap::new();
-    for record in inline_index_records {
-        inline_index_records_map
-            .entry(record.index_id)
-            .or_default()
-            .push(record);
-    }
-
-    // append index builders
-    for (_index_name, builder) in index_builder_map.iter_mut() {
-        let index_def = builder.index_def();
-
-        if let Some(records) = inline_index_records_map.get(&index_def.index_id) {
-            for record in records {
-                builder.read_bytes(&record.index_data)?;
-            }
-        }
-    }
-
-    // filter row ids by indexes
-    let mut filter_index_entries_list = Vec::new();
-    for (index_name, filter_indices) in index_filter_assignment.iter() {
-        let index_builder = index_builder_map.get_mut(index_name).ok_or_else(|| {
-            ILError::internal(format!("Index builder not found for index {index_name}"))
-        })?;
-
-        let index = index_builder.build()?;
-
         let filters = filter_indices
             .iter()
             .map(|idx| scan.filters[*idx].clone())
             .collect::<Vec<_>>();
 
-        let filter_index_entries = index.filter(&filters).await?;
-        filter_index_entries_list.push(filter_index_entries);
+        let mut all_valid_row_ids = HashSet::new();
+
+        let Some(records) = inline_index_records_map.get(&index_def.index_id) else {
+            // No inline index records for this index, return empty set
+            filter_index_entries_list.push(FilterIndexEntries {
+                row_ids: Vec::new(),
+            });
+            continue;
+        };
+
+        // For each segment, build a mini-index and filter
+        for record in records {
+            let mut builder = index_kind.builder(index_def)?;
+            builder.read_bytes(&record.index_data)?;
+            let index = builder.build()?;
+            let entries = index.filter(&filters).await?;
+
+            // Only keep row_ids that are still valid in this segment
+            for row_id in entries.row_ids {
+                if let Some(pos) = record.row_ids.iter().position(|r| *r == row_id)
+                    && record.validity.is_valid(pos)
+                {
+                    all_valid_row_ids.insert(row_id);
+                }
+            }
+        }
+
+        filter_index_entries_list.push(FilterIndexEntries {
+            row_ids: all_valid_row_ids.into_iter().collect(),
+        });
     }
 
     let mut intersected_row_ids = filter_index_entries_list[0]

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::catalog::{
     CatalogHelper, CatalogSchema, DataFileRecord, INTERNAL_ROW_ID_FIELD_NAME, IndexFileRecord,
-    InlineIndexRecord, Row, rows_to_record_batch,
+    InlineIndexRecord, Row, RowValidity, rows_to_record_batch,
 };
 use crate::expr::row_ids_in_list_expr;
 use crate::index::{DynamicColumn, IndexDefinitionRef, IndexKind, SearchIndexEntries, SearchQuery};
@@ -230,19 +230,71 @@ async fn search_inline_rows(
     search: &TableSearch,
     inline_index_records: Vec<InlineIndexRecord>,
 ) -> ILResult<SearchIndexEntries> {
-    let mut index_builder = index_kind.builder(index_def)?;
+    // Build set of valid row_ids per segment
+    let mut all_row_ids = Vec::new();
+    let mut all_scores = Vec::new();
+    let mut all_dynamic_column_groups: Vec<Vec<DynamicColumn>> = Vec::new();
+    let mut score_higher_is_better = false;
 
-    for record in inline_index_records {
-        index_builder.read_bytes(&record.index_data)?;
+    for record in &inline_index_records {
+        let mut builder = index_kind.builder(index_def)?;
+        builder.read_bytes(&record.index_data)?;
+        let index = builder.build()?;
+
+        let entries = index
+            .search(
+                search.query.as_ref(),
+                &search.dynamic_fields,
+                &record.validity,
+            )
+            .await?;
+        score_higher_is_better = entries.score_higher_is_better;
+
+        // Filter results by validity (for index implementations that don't filter internally)
+        let mut kept_positions = Vec::new();
+        for (i, row_id) in entries.row_ids.iter().enumerate() {
+            if let Some(pos) = record.row_ids.iter().position(|r| r == row_id)
+                && record.validity.is_valid(pos)
+            {
+                all_row_ids.push(*row_id);
+                all_scores.push(entries.scores[i]);
+                kept_positions.push(i as u32);
+            }
+        }
+
+        // Filter dynamic columns for this delta
+        if !entries.dynamic_columns.is_empty() {
+            let indices = arrow::array::UInt32Array::from(kept_positions);
+            let filtered_dynamic_columns: Vec<DynamicColumn> = entries
+                .dynamic_columns
+                .into_iter()
+                .map(|col| {
+                    let filtered_values =
+                        arrow::compute::take(col.values.as_ref(), &indices, None)?;
+                    Ok(DynamicColumn {
+                        field: col.field,
+                        values: filtered_values,
+                    })
+                })
+                .collect::<arrow::error::Result<Vec<_>>>()
+                .map_err(|e| ILError::internal(format!("Failed to filter dynamic columns: {e}")))?;
+            all_dynamic_column_groups.push(filtered_dynamic_columns);
+        }
     }
 
-    let index = index_builder.build()?;
+    // Merge dynamic columns from all deltas
+    let merged_dynamic_columns = if all_dynamic_column_groups.is_empty() {
+        Vec::new()
+    } else {
+        concat_dynamic_columns(&all_dynamic_column_groups)?
+    };
 
-    let search_index_entries = index
-        .search(search.query.as_ref(), &search.dynamic_fields)
-        .await?;
-
-    Ok(search_index_entries)
+    Ok(SearchIndexEntries {
+        row_ids: all_row_ids,
+        scores: all_scores,
+        score_higher_is_better,
+        dynamic_columns: merged_dynamic_columns,
+    })
 }
 
 async fn search_index_file(
@@ -260,7 +312,11 @@ async fn search_index_file(
 
     let index = index_builder.build()?;
 
-    let search_index_entries = index.search(search_query, dynamic_fields).await?;
+    // File-based index: all rows are valid
+    let validity = RowValidity::all_valid();
+    let search_index_entries = index
+        .search(search_query, dynamic_fields, &validity)
+        .await?;
 
     Ok(search_index_entries)
 }

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -312,8 +312,10 @@ async fn search_index_file(
 
     let index = index_builder.build()?;
 
-    // File-based index: all rows are valid
-    let validity = RowValidity::all_valid();
+    // File-based index: create validity bitmap with all rows valid
+    // (file-based indexes don't track per-row validity; filtering happens at table layer)
+    let num_rows = index.num_rows();
+    let validity = RowValidity::new(num_rows);
     let search_index_entries = index
         .search(search_query, dynamic_fields, &validity)
         .await?;

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -143,6 +143,7 @@ pub(crate) async fn process_search(
         let index_def = index_def.clone();
         let search_query = search.query.clone();
         let dynamic_fields = search.dynamic_fields.clone();
+        let validity = data_file_record.validity.clone();
         let handle = tokio::spawn(async move {
             let search_entries = search_index_file(
                 storage.as_ref(),
@@ -151,6 +152,7 @@ pub(crate) async fn process_search(
                 search_query.as_ref(),
                 &index_file_record,
                 &dynamic_fields,
+                &validity,
             )
             .await?;
             Ok::<_, ILError>((data_file_id, search_entries))
@@ -304,6 +306,7 @@ async fn search_index_file(
     search_query: &dyn SearchQuery,
     index_file_record: &IndexFileRecord,
     dynamic_fields: &[String],
+    validity: &RowValidity,
 ) -> ILResult<SearchIndexEntries> {
     let index_file = storage.open(&index_file_record.relative_path).await?;
 
@@ -312,13 +315,7 @@ async fn search_index_file(
 
     let index = index_builder.build()?;
 
-    // File-based index: create validity bitmap with all rows valid
-    // (file-based indexes don't track per-row validity; filtering happens at table layer)
-    let num_rows = index.num_rows();
-    let validity = RowValidity::new(num_rows);
-    let search_index_entries = index
-        .search(search_query, dynamic_fields, &validity)
-        .await?;
+    let search_index_entries = index.search(search_query, dynamic_fields, validity).await?;
 
     Ok(search_index_entries)
 }

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -251,36 +251,10 @@ async fn search_inline_rows(
             )
             .await?;
         score_higher_is_better = entries.score_higher_is_better;
-
-        // Filter results by validity (for index implementations that don't filter internally)
-        let mut kept_positions = Vec::new();
-        for (i, row_id) in entries.row_ids.iter().enumerate() {
-            if let Some(pos) = record.row_ids.iter().position(|r| r == row_id)
-                && record.validity.is_valid(pos)
-            {
-                all_row_ids.push(*row_id);
-                all_scores.push(entries.scores[i]);
-                kept_positions.push(i as u32);
-            }
-        }
-
-        // Filter dynamic columns for this delta
+        all_row_ids.extend(entries.row_ids);
+        all_scores.extend(entries.scores);
         if !entries.dynamic_columns.is_empty() {
-            let indices = arrow::array::UInt32Array::from(kept_positions);
-            let filtered_dynamic_columns: Vec<DynamicColumn> = entries
-                .dynamic_columns
-                .into_iter()
-                .map(|col| {
-                    let filtered_values =
-                        arrow::compute::take(col.values.as_ref(), &indices, None)?;
-                    Ok(DynamicColumn {
-                        field: col.field,
-                        values: filtered_values,
-                    })
-                })
-                .collect::<arrow::error::Result<Vec<_>>>()
-                .map_err(|e| ILError::internal(format!("Failed to filter dynamic columns: {e}")))?;
-            all_dynamic_column_groups.push(filtered_dynamic_columns);
+            all_dynamic_column_groups.push(entries.dynamic_columns);
         }
     }
 


### PR DESCRIPTION
## PR2b: Index trait validity + read path + delete

Part of the PR #167 split (2/3). Depends on PR #168 (merged).

### Changes
- **Index trait**: Add `validity: &RowValidity` to `Index::search`
- **BM25**: scorer filters by validity internally (skip invalid doc_id)
- **HNSW**: over-fetch with `scanned_count`, skip invalid neighbors, progressive fetch_limit
- **RabitQ**: over-fetch with `scanned_count`, skip invalid results, progressive fetch_limit
- **BTree/RStar**: accept validity parameter (stub, search not supported)
- **Read path**: pass segment validity to inline index search; pass data file validity to file index search; filter dynamic columns by kept positions
- **Scan path**: filter results by validity using row_id position lookup
- **Delete path**: mark deleted rows as invalid in inline index segments (`invalidate_inline_index_rows`)

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)
- ✅ index_hnsw, index_bm25, index_btree, table_update (all case_1)

### Notes
- Update indexed column path (old validity=false + new segment) deferred to PR2c
- File-based index search uses real data file validity, not a sentinel