### PR TITLE
refactor: RowValidity::is_valid() returns Result instead of panicking

### DIFF
--- a/indexes/bm25/src/scorer.rs
+++ b/indexes/bm25/src/scorer.rs
@@ -297,7 +297,7 @@ impl ArrowScorer {
         let mut scores = Vec::new();
         for (doc_id, &score) in scores_by_doc_id.iter().enumerate() {
             if score > 0.0 {
-                if !validity.is_valid(doc_id) {
+                if !validity.is_valid(doc_id)? {
                     continue;
                 }
                 scores.push(ScoredDocument {

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -70,7 +70,7 @@ impl Index for HnswIndex {
         while row_ids.len() < query.limit && fetch_limit <= total {
             let neighbors = self.hnsw.knn(&query.vector, fetch_limit);
             for neighbor in &neighbors[scanned_count..] {
-                if validity.is_valid(neighbor.index) {
+                if validity.is_valid(neighbor.index)? {
                     row_ids.push(self.row_ids[neighbor.index]);
                     scores.push(neighbor.distance as f64);
                     if row_ids.len() >= query.limit {

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -77,7 +77,7 @@ impl Index for RabitqIndex {
                 .search(&query.vector, params)
                 .map_err(|e| ILError::index(format!("RaBitQ brute force search failed: {e}")))?;
             for r in &results[scanned_count..] {
-                if validity.is_valid(r.id) {
+                if validity.is_valid(r.id)? {
                     row_ids.push(self.row_ids[r.id]);
                     scores.push(r.score as f64);
                     if row_ids.len() >= query.limit {

--- a/indexlake/src/catalog/helper/update.rs
+++ b/indexlake/src/catalog/helper/update.rs
@@ -199,7 +199,7 @@ impl TransactionHelper {
             let mut modified = false;
 
             for (i, row_id) in row_ids.iter().enumerate() {
-                if invalid_row_ids.contains(row_id) && validity.is_valid(i) {
+                if invalid_row_ids.contains(row_id) && validity.is_valid(i)? {
                     validity.set(i, false);
                     modified = true;
                 }

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -370,11 +370,16 @@ impl RowValidity {
         &self.validity
     }
 
-    pub fn is_valid(&self, row_idx: usize) -> bool {
-        assert!(row_idx < self.num_rows);
+    pub fn is_valid(&self, row_idx: usize) -> ILResult<bool> {
+        if row_idx >= self.num_rows {
+            return Err(ILError::internal(format!(
+                "RowValidity index out of bounds: {row_idx} >= {}",
+                self.num_rows
+            )));
+        }
         let byte_idx = row_idx / 8;
         let bit_idx = row_idx % 8;
-        (self.validity[byte_idx] & (1 << bit_idx)) != 0
+        Ok((self.validity[byte_idx] & (1 << bit_idx)) != 0)
     }
 }
 

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -469,7 +469,7 @@ async fn index_scan_inline_rows(
             // Only keep row_ids that are still valid in this segment
             for row_id in entries.row_ids {
                 if let Some(pos) = record.row_ids.iter().position(|r| *r == row_id)
-                    && record.validity.is_valid(pos)
+                    && record.validity.is_valid(pos)?
                 {
                     all_valid_row_ids.insert(row_id);
                 }


### PR DESCRIPTION
Change `is_valid()` from `-> bool` (with `assert!`) to `-> ILResult<bool>` (with proper error return).

### Changes
- `RowValidity::is_valid()`: out-of-bounds returns `Err(ILError::internal(...))` instead of panicking
- Updated all 5 callers to propagate errors with `?`:
  - BM25 scorer
  - HNSW index
  - RabitQ index  
  - `invalidate_inline_index_rows`
  - scan.rs filter path

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)