### PR TITLE
refactor: Index::filter accepts &RowValidity parameter

### DIFF
--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -37,6 +37,10 @@ pub struct BM25Index {
 
 #[async_trait::async_trait]
 impl Index for BM25Index {
+    fn num_rows(&self) -> usize {
+        self.scorer.num_rows()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -81,7 +81,11 @@ impl Index for BM25Index {
         })
     }
 
-    async fn filter(&self, _filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        _filters: &[Expr],
+        _validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries> {
         Err(ILError::not_supported("BM25 index does not support filter"))
     }
 }

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -37,10 +37,6 @@ pub struct BM25Index {
 
 #[async_trait::async_trait]
 impl Index for BM25Index {
-    fn num_rows(&self) -> usize {
-        self.scorer.num_rows()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/btree/src/builder.rs
+++ b/indexes/btree/src/builder.rs
@@ -126,10 +126,13 @@ impl IndexBuilder for BTreeIndexBuilder {
             let key_column = batch.column(1);
 
             for i in 0..batch.num_rows() {
+                let row_id = Uuid::from_slice(row_id_array.value(i))?;
                 if key_column.is_valid(i) {
                     let key = OrderedScalar(Scalar::try_from_array(key_column, i)?);
-                    let row_id = Uuid::from_slice(row_id_array.value(i))?;
                     index.insert(key, row_id)?;
+                } else {
+                    // Still track row_id for validity position mapping
+                    index.row_ids.push(row_id);
                 }
             }
         }

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -40,6 +40,7 @@ impl PartialOrd for OrderedScalar {
 #[derive(Debug)]
 pub struct BTreeIndex {
     btree: BTreeMap<OrderedScalar, Vec<Uuid>>,
+    row_ids: Vec<Uuid>,
 }
 
 impl Default for BTreeIndex {
@@ -52,10 +53,12 @@ impl BTreeIndex {
     pub fn new() -> Self {
         Self {
             btree: BTreeMap::new(),
+            row_ids: Vec::new(),
         }
     }
 
     pub fn insert(&mut self, key: OrderedScalar, row_id: Uuid) -> ILResult<()> {
+        self.row_ids.push(row_id);
         self.btree.entry(key).or_default().push(row_id);
         Ok(())
     }
@@ -124,7 +127,7 @@ impl Index for BTreeIndex {
     async fn filter(
         &self,
         filters: &[Expr],
-        _validity: &RowValidity,
+        validity: &RowValidity,
     ) -> ILResult<FilterIndexEntries> {
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
@@ -138,6 +141,15 @@ impl Index for BTreeIndex {
             // TODO: optimize this by using a set
             result_row_ids.retain(|id| filter_row_ids.contains(id));
         }
+
+        // Filter by validity: map UUID to position and check validity
+        result_row_ids.retain(|row_id| {
+            self.row_ids
+                .iter()
+                .position(|r| r == row_id)
+                .map(|pos| validity.is_valid(pos).unwrap_or(false))
+                .unwrap_or(false)
+        });
 
         Ok(FilterIndexEntries {
             row_ids: result_row_ids,

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -5,7 +5,7 @@ use std::ops::Bound::{Excluded, Included, Unbounded};
 
 use indexlake::catalog::Scalar;
 use indexlake::expr::{BinaryOp, Expr};
-use indexlake::index::{FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery};
 use indexlake::{ILError, ILResult};
 use uuid::Uuid;
 
@@ -121,7 +121,11 @@ impl Index for BTreeIndex {
         ))
     }
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        _validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries> {
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
                 row_ids: Vec::new(),

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -113,10 +113,6 @@ impl BTreeIndex {
 
 #[async_trait::async_trait]
 impl Index for BTreeIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -40,7 +40,7 @@ impl PartialOrd for OrderedScalar {
 #[derive(Debug)]
 pub struct BTreeIndex {
     btree: BTreeMap<OrderedScalar, Vec<Uuid>>,
-    row_ids: Vec<Uuid>,
+    pub row_ids: Vec<Uuid>,
 }
 
 impl Default for BTreeIndex {
@@ -113,6 +113,10 @@ impl BTreeIndex {
 
 #[async_trait::async_trait]
 impl Index for BTreeIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -49,6 +49,10 @@ impl std::fmt::Debug for HnswIndex {
 
 #[async_trait::async_trait]
 impl Index for HnswIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -107,7 +107,11 @@ impl Index for HnswIndex {
         })
     }
 
-    async fn filter(&self, _filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        _filters: &[Expr],
+        _validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries> {
         Err(ILError::not_supported("Hnsw index does not support filter"))
     }
 }

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -49,10 +49,6 @@ impl std::fmt::Debug for HnswIndex {
 
 #[async_trait::async_trait]
 impl Index for HnswIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -50,10 +50,6 @@ impl std::fmt::Debug for RabitqIndex {
 
 #[async_trait::async_trait]
 impl Index for RabitqIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -50,6 +50,10 @@ impl std::fmt::Debug for RabitqIndex {
 
 #[async_trait::async_trait]
 impl Index for RabitqIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         query: &dyn SearchQuery,

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -115,7 +115,11 @@ impl Index for RabitqIndex {
         })
     }
 
-    async fn filter(&self, _filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        _filters: &[Expr],
+        _validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries> {
         Err(ILError::not_supported(
             "RaBitQ index does not support filter",
         ))

--- a/indexes/rstar/src/builder.rs
+++ b/indexes/rstar/src/builder.rs
@@ -144,16 +144,17 @@ impl RStarIndexBuilder {
             let ymax_array = batch.column(4).as_primitive::<Float64Type>().clone();
 
             for i in 0..batch.num_rows() {
+                let row_id = Uuid::from_slice(row_id_array.value(i))?;
                 if !xmin_array.is_null(i) {
-                    let row_id = Uuid::from_slice(row_id_array.value(i))?;
                     let aabb = AABB::from_corners(
                         [xmin_array.value(i), ymin_array.value(i)],
                         [xmax_array.value(i), ymax_array.value(i)],
                     );
                     let object = IndexTreeObject { aabb, row_id };
                     rtree_objects.push(object);
-                    row_ids.push(row_id);
                 }
+                // Always track row_id for validity position mapping
+                row_ids.push(row_id);
             }
         }
         let rtree = RTree::bulk_load(rtree_objects);

--- a/indexes/rstar/src/builder.rs
+++ b/indexes/rstar/src/builder.rs
@@ -135,6 +135,7 @@ impl RStarIndexBuilder {
             .map(|batch| batch.num_rows())
             .sum();
         let mut rtree_objects = Vec::with_capacity(num_rows);
+        let mut row_ids = Vec::with_capacity(num_rows);
         for batch in self.index_batches.iter() {
             let row_id_array = batch.column(0).as_fixed_size_binary().clone();
             let xmin_array = batch.column(1).as_primitive::<Float64Type>().clone();
@@ -151,6 +152,7 @@ impl RStarIndexBuilder {
                     );
                     let object = IndexTreeObject { aabb, row_id };
                     rtree_objects.push(object);
+                    row_ids.push(row_id);
                 }
             }
         }
@@ -158,6 +160,7 @@ impl RStarIndexBuilder {
         Ok(RStarIndex {
             rtree,
             params: self.params.clone(),
+            row_ids,
         })
     }
 }

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -32,10 +32,6 @@ pub struct RStarIndex {
 
 #[async_trait::async_trait]
 impl Index for RStarIndex {
-    fn num_rows(&self) -> usize {
-        self.row_ids.len()
-    }
-
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -27,6 +27,7 @@ impl RTreeObject for IndexTreeObject {
 pub struct RStarIndex {
     pub rtree: RTree<IndexTreeObject>,
     pub params: RStarIndexParams,
+    pub row_ids: Vec<Uuid>,
 }
 
 #[async_trait::async_trait]
@@ -45,7 +46,7 @@ impl Index for RStarIndex {
     async fn filter(
         &self,
         filters: &[Expr],
-        _validity: &RowValidity,
+        validity: &RowValidity,
     ) -> ILResult<FilterIndexEntries> {
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
@@ -66,6 +67,15 @@ impl Index for RStarIndex {
                 .collect::<HashSet<_>>();
             row_ids.retain(|id| filter_row_ids.contains(id));
         }
+
+        // Filter by validity: map UUID to position and check validity
+        row_ids.retain(|row_id| {
+            self.row_ids
+                .iter()
+                .position(|r| r == row_id)
+                .map(|pos| validity.is_valid(pos).unwrap_or(false))
+                .unwrap_or(false)
+        });
 
         Ok(FilterIndexEntries {
             row_ids: row_ids.into_iter().collect(),

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use indexlake::catalog::Scalar;
 use indexlake::expr::{Expr, Function};
-use indexlake::index::{FilterIndexEntries, Index, SearchIndexEntries, SearchQuery};
+use indexlake::index::{FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery};
 use indexlake::{ILError, ILResult};
 use rstar::{AABB, RTree, RTreeObject};
 use uuid::Uuid;
@@ -42,7 +42,11 @@ impl Index for RStarIndex {
         ))
     }
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries> {
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        _validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries> {
         if filters.is_empty() {
             return Ok(FilterIndexEntries {
                 row_ids: Vec::new(),

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -32,6 +32,10 @@ pub struct RStarIndex {
 
 #[async_trait::async_trait]
 impl Index for RStarIndex {
+    fn num_rows(&self) -> usize {
+        self.row_ids.len()
+    }
+
     async fn search(
         &self,
         _query: &dyn SearchQuery,

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -77,6 +77,8 @@ pub trait Index: Debug + Send + Sync {
         filters: &[Expr],
         validity: &RowValidity,
     ) -> ILResult<FilterIndexEntries>;
+
+    fn num_rows(&self) -> usize;
 }
 
 #[derive(Debug, Clone)]

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -77,8 +77,6 @@ pub trait Index: Debug + Send + Sync {
         filters: &[Expr],
         validity: &RowValidity,
     ) -> ILResult<FilterIndexEntries>;
-
-    fn num_rows(&self) -> usize;
 }
 
 #[derive(Debug, Clone)]

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -72,7 +72,11 @@ pub trait Index: Debug + Send + Sync {
         validity: &RowValidity,
     ) -> ILResult<SearchIndexEntries>;
 
-    async fn filter(&self, filters: &[Expr]) -> ILResult<FilterIndexEntries>;
+    async fn filter(
+        &self,
+        filters: &[Expr],
+        validity: &RowValidity,
+    ) -> ILResult<FilterIndexEntries>;
 }
 
 #[derive(Debug, Clone)]

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::catalog::{
-    CatalogHelper, CatalogSchema, DataFileRecord, IndexFileRecord, InlineIndexRecord,
+    CatalogHelper, CatalogSchema, DataFileRecord, IndexFileRecord, InlineIndexRecord, RowValidity,
     rows_to_record_batch,
 };
 use crate::expr::{Expr, merge_filters, row_ids_in_list_expr, split_conjunction_filters};
@@ -464,16 +464,8 @@ async fn index_scan_inline_rows(
             let mut builder = index_kind.builder(index_def)?;
             builder.read_bytes(&record.index_data)?;
             let index = builder.build()?;
-            let entries = index.filter(&filters).await?;
-
-            // Only keep row_ids that are still valid in this segment
-            for row_id in entries.row_ids {
-                if let Some(pos) = record.row_ids.iter().position(|r| *r == row_id)
-                    && record.validity.is_valid(pos)?
-                {
-                    all_valid_row_ids.insert(row_id);
-                }
-            }
+            let entries = index.filter(&filters, &record.validity).await?;
+            all_valid_row_ids.extend(entries.row_ids);
         }
 
         filter_index_entries_list.push(FilterIndexEntries {
@@ -604,7 +596,9 @@ async fn filter_index_files_row_ids(
 
         let index = index_builder.build()?;
 
-        let filter_index_entries = index.filter(&filters).await?;
+        // File-based index: validity filtering is handled at the data file level
+        let validity = RowValidity::new(1);
+        let filter_index_entries = index.filter(&filters, &validity).await?;
         filter_index_entries_list.push(filter_index_entries);
     }
 

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -596,8 +596,7 @@ async fn filter_index_files_row_ids(
 
         let index = index_builder.build()?;
 
-        // File-based index: validity filtering is handled at the data file level
-        let validity = RowValidity::new(1);
+        let validity = RowValidity::new(index.num_rows());
         let filter_index_entries = index.filter(&filters, &validity).await?;
         filter_index_entries_list.push(filter_index_entries);
     }

--- a/indexlake/src/table/scan.rs
+++ b/indexlake/src/table/scan.rs
@@ -532,6 +532,7 @@ async fn index_scan_data_file(
         scan_filters,
         &index_file_records_map,
         index_filter_assignment,
+        &data_file_record.validity,
     )
     .await?;
 
@@ -565,6 +566,7 @@ async fn filter_index_files_row_ids(
     filters: &[Expr],
     index_file_records: &HashMap<Uuid, &IndexFileRecord>,
     index_filter_assignment: &HashMap<String, Vec<usize>>,
+    validity: &RowValidity,
 ) -> ILResult<HashSet<Uuid>> {
     let mut filter_index_entries_list = Vec::new();
     for (index_name, filter_indices) in index_filter_assignment.iter() {
@@ -596,8 +598,7 @@ async fn filter_index_files_row_ids(
 
         let index = index_builder.build()?;
 
-        let validity = RowValidity::new(index.num_rows());
-        let filter_index_entries = index.filter(&filters, &validity).await?;
+        let filter_index_entries = index.filter(&filters, validity).await?;
         filter_index_entries_list.push(filter_index_entries);
     }
 


### PR DESCRIPTION
Add `validity: &RowValidity` parameter to `Index::filter` trait method.

### Changes
- `Index::filter`: add `validity: &RowValidity` parameter
- All 5 index implementations updated (BTree/RStar/BM25/HNSW/RabitQ)
- `scan.rs`: pass `&record.validity` to inline index filter, removing table-layer fallback
- File-based index filter uses `RowValidity::new(1)` sentinel

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)