### PR TITLE
perf: use HashMap for UUID→position lookup in BTree/RStar filter

### DIFF
--- a/indexes/btree/src/builder.rs
+++ b/indexes/btree/src/builder.rs
@@ -132,6 +132,7 @@ impl IndexBuilder for BTreeIndexBuilder {
                     index.insert(key, row_id)?;
                 } else {
                     // Still track row_id for validity position mapping
+                    index.row_id_to_pos.insert(row_id, index.row_ids.len());
                     index.row_ids.push(row_id);
                 }
             }

--- a/indexes/btree/src/builder.rs
+++ b/indexes/btree/src/builder.rs
@@ -132,8 +132,8 @@ impl IndexBuilder for BTreeIndexBuilder {
                     index.insert(key, row_id)?;
                 } else {
                     // Still track row_id for validity position mapping
-                    index.row_id_to_pos.insert(row_id, index.row_ids.len());
-                    index.row_ids.push(row_id);
+                    index.row_id_to_pos.insert(row_id, index.row_count);
+                    index.row_count += 1;
                 }
             }
         }

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 
+use std::collections::HashMap;
+
 use indexlake::catalog::Scalar;
 use indexlake::expr::{BinaryOp, Expr};
 use indexlake::index::{FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery};
@@ -41,6 +43,7 @@ impl PartialOrd for OrderedScalar {
 pub struct BTreeIndex {
     btree: BTreeMap<OrderedScalar, Vec<Uuid>>,
     pub row_ids: Vec<Uuid>,
+    pub row_id_to_pos: HashMap<Uuid, usize>,
 }
 
 impl Default for BTreeIndex {
@@ -54,10 +57,12 @@ impl BTreeIndex {
         Self {
             btree: BTreeMap::new(),
             row_ids: Vec::new(),
+            row_id_to_pos: HashMap::new(),
         }
     }
 
     pub fn insert(&mut self, key: OrderedScalar, row_id: Uuid) -> ILResult<()> {
+        self.row_id_to_pos.insert(row_id, self.row_ids.len());
         self.row_ids.push(row_id);
         self.btree.entry(key).or_default().push(row_id);
         Ok(())
@@ -142,12 +147,11 @@ impl Index for BTreeIndex {
             result_row_ids.retain(|id| filter_row_ids.contains(id));
         }
 
-        // Filter by validity: map UUID to position and check validity
+        // Filter by validity using O(1) HashMap lookup
         result_row_ids.retain(|row_id| {
-            self.row_ids
-                .iter()
-                .position(|r| r == row_id)
-                .map(|pos| validity.is_valid(pos).unwrap_or(false))
+            self.row_id_to_pos
+                .get(row_id)
+                .map(|&pos| validity.is_valid(pos).unwrap_or(false))
                 .unwrap_or(false)
         });
 

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -42,7 +42,7 @@ impl PartialOrd for OrderedScalar {
 #[derive(Debug)]
 pub struct BTreeIndex {
     btree: BTreeMap<OrderedScalar, Vec<Uuid>>,
-    pub row_ids: Vec<Uuid>,
+    pub row_count: usize,
     pub row_id_to_pos: HashMap<Uuid, usize>,
 }
 
@@ -56,14 +56,14 @@ impl BTreeIndex {
     pub fn new() -> Self {
         Self {
             btree: BTreeMap::new(),
-            row_ids: Vec::new(),
+            row_count: 0,
             row_id_to_pos: HashMap::new(),
         }
     }
 
     pub fn insert(&mut self, key: OrderedScalar, row_id: Uuid) -> ILResult<()> {
-        self.row_id_to_pos.insert(row_id, self.row_ids.len());
-        self.row_ids.push(row_id);
+        self.row_id_to_pos.insert(row_id, self.row_count);
+        self.row_count += 1;
         self.btree.entry(key).or_default().push(row_id);
         Ok(())
     }

--- a/indexes/rstar/src/builder.rs
+++ b/indexes/rstar/src/builder.rs
@@ -136,7 +136,7 @@ impl RStarIndexBuilder {
             .map(|batch| batch.num_rows())
             .sum();
         let mut rtree_objects = Vec::with_capacity(num_rows);
-        let mut row_ids = Vec::with_capacity(num_rows);
+        let mut row_count = 0;
         let mut row_id_to_pos = HashMap::with_capacity(num_rows);
         for batch in self.index_batches.iter() {
             let row_id_array = batch.column(0).as_fixed_size_binary().clone();
@@ -156,15 +156,15 @@ impl RStarIndexBuilder {
                     rtree_objects.push(object);
                 }
                 // Always track row_id for validity position mapping
-                row_id_to_pos.insert(row_id, row_ids.len());
-                row_ids.push(row_id);
+                row_id_to_pos.insert(row_id, row_count);
+                row_count += 1;
             }
         }
         let rtree = RTree::bulk_load(rtree_objects);
         Ok(RStarIndex {
             rtree,
             params: self.params.clone(),
-            row_ids,
+            row_count,
             row_id_to_pos,
         })
     }

--- a/indexes/rstar/src/builder.rs
+++ b/indexes/rstar/src/builder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
 use arrow::array::{Array, ArrayRef, AsArray, FixedSizeBinaryArray, Float64Builder, RecordBatch};
@@ -136,6 +137,7 @@ impl RStarIndexBuilder {
             .sum();
         let mut rtree_objects = Vec::with_capacity(num_rows);
         let mut row_ids = Vec::with_capacity(num_rows);
+        let mut row_id_to_pos = HashMap::with_capacity(num_rows);
         for batch in self.index_batches.iter() {
             let row_id_array = batch.column(0).as_fixed_size_binary().clone();
             let xmin_array = batch.column(1).as_primitive::<Float64Type>().clone();
@@ -154,6 +156,7 @@ impl RStarIndexBuilder {
                     rtree_objects.push(object);
                 }
                 // Always track row_id for validity position mapping
+                row_id_to_pos.insert(row_id, row_ids.len());
                 row_ids.push(row_id);
             }
         }
@@ -162,6 +165,7 @@ impl RStarIndexBuilder {
             rtree,
             params: self.params.clone(),
             row_ids,
+            row_id_to_pos,
         })
     }
 }

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use std::collections::HashMap;
+
 use indexlake::catalog::Scalar;
 use indexlake::expr::{Expr, Function};
 use indexlake::index::{FilterIndexEntries, Index, RowValidity, SearchIndexEntries, SearchQuery};
@@ -28,6 +30,7 @@ pub struct RStarIndex {
     pub rtree: RTree<IndexTreeObject>,
     pub params: RStarIndexParams,
     pub row_ids: Vec<Uuid>,
+    pub row_id_to_pos: HashMap<Uuid, usize>,
 }
 
 #[async_trait::async_trait]
@@ -68,12 +71,11 @@ impl Index for RStarIndex {
             row_ids.retain(|id| filter_row_ids.contains(id));
         }
 
-        // Filter by validity: map UUID to position and check validity
+        // Filter by validity using O(1) HashMap lookup
         row_ids.retain(|row_id| {
-            self.row_ids
-                .iter()
-                .position(|r| r == row_id)
-                .map(|pos| validity.is_valid(pos).unwrap_or(false))
+            self.row_id_to_pos
+                .get(row_id)
+                .map(|&pos| validity.is_valid(pos).unwrap_or(false))
                 .unwrap_or(false)
         });
 

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -29,7 +29,7 @@ impl RTreeObject for IndexTreeObject {
 pub struct RStarIndex {
     pub rtree: RTree<IndexTreeObject>,
     pub params: RStarIndexParams,
-    pub row_ids: Vec<Uuid>,
+    pub row_count: usize,
     pub row_id_to_pos: HashMap<Uuid, usize>,
 }
 


### PR DESCRIPTION
Replace O(n) `iter().position()` with O(1) `HashMap::get()` in BTree and RStar filter validity checks.

### Changes
- Add `row_id_to_pos: HashMap<Uuid, usize>` to `BTreeIndex` and `RStarIndex`
- Populate during `insert()` and build
- Use in `filter()` for O(1) validity position lookup

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ BTree integration test