### PR TITLE
feat: delete fully-invalid inline index records

### DIFF
--- a/indexlake/src/catalog/helper/update.rs
+++ b/indexlake/src/catalog/helper/update.rs
@@ -206,17 +206,29 @@ impl TransactionHelper {
             }
 
             if modified {
-                // Update the record in the database
-                let update_count = self
-                    .transaction
-                    .execute(&format!(
-                        "UPDATE indexlake_inline_index SET validity = {} WHERE index_id = {} AND created_at = {}",
-                        self.catalog.sql_binary_literal(validity.bytes()),
-                        self.catalog.sql_uuid_literal(&idx_id),
-                        idx_created_at,
-                    ))
-                    .await?;
-                updated_count += update_count;
+                if validity.count_valid() == 0 {
+                    // All rows invalid: delete the record entirely
+                    let delete_count = self
+                        .transaction
+                        .execute(&format!(
+                            "DELETE FROM indexlake_inline_index WHERE index_id = {} AND created_at = {}",
+                            self.catalog.sql_uuid_literal(&idx_id),
+                            idx_created_at,
+                        ))
+                        .await?;
+                    updated_count += delete_count;
+                } else {
+                    let update_count = self
+                        .transaction
+                        .execute(&format!(
+                            "UPDATE indexlake_inline_index SET validity = {} WHERE index_id = {} AND created_at = {}",
+                            self.catalog.sql_binary_literal(validity.bytes()),
+                            self.catalog.sql_uuid_literal(&idx_id),
+                            idx_created_at,
+                        ))
+                        .await?;
+                    updated_count += update_count;
+                }
             }
         }
 


### PR DESCRIPTION
When updating validity in `invalidate_inline_index_rows`, if all rows in a record become invalid (`count_valid() == 0`), DELETE the record instead of keeping an empty validity bitmap.

This is a form of micro-compaction — fully-invalid segments are removed immediately rather than accumulating.

### Changes
- `invalidate_inline_index_rows`: after invalidation, check if all rows are invalid
- If `validity.count_valid() == 0`: DELETE the record
- Otherwise: UPDATE validity as before

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)
- ✅ table_update case_1 (5/5)