### PR TITLE
feat: add RebuildInlineIndexes optimization for manual compaction

### DIFF
--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -21,7 +21,7 @@ use crate::{
 pub enum TableOptimization {
     CleanupOrphanFiles { last_modified_before: i64 },
     MergeDataFiles { valid_row_threshold: usize },
-    RebuildInlineIndexes,
+    RebuildInlineIndexes { index_ids: Option<Vec<Uuid>> },
 }
 
 pub(crate) async fn process_table_optimization(
@@ -35,18 +35,23 @@ pub(crate) async fn process_table_optimization(
         TableOptimization::MergeDataFiles {
             valid_row_threshold,
         } => merge_data_files(table, valid_row_threshold).await,
-        TableOptimization::RebuildInlineIndexes => rebuild_inline_indexes_from_scratch(table).await,
+        TableOptimization::RebuildInlineIndexes { index_ids } => {
+            rebuild_inline_indexes_from_scratch(table, index_ids.as_deref()).await
+        }
     }
 }
 
-async fn rebuild_inline_indexes_from_scratch(table: &Table) -> ILResult<()> {
+async fn rebuild_inline_indexes_from_scratch(
+    table: &Table,
+    index_ids: Option<&[Uuid]>,
+) -> ILResult<()> {
     let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
     rebuild_inline_indexes(
         &mut tx_helper,
         &table.table_id,
         &table.table_schema,
         &table.index_manager,
-        None,
+        index_ids,
     )
     .await?;
     tx_helper.commit().await?;

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -62,6 +62,22 @@ async fn rebuild_inline_indexes_from_scratch(
     table: &Table,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
+    let task_id = format!("rebuild-inline-indexes-{}", table.table_id);
+    if insert_task(
+        &table.catalog,
+        task_id.clone(),
+        Duration::from_secs(24 * 60 * 60),
+    )
+    .await
+    .is_err()
+    {
+        debug!(
+            "[indexlake] Table {} already has a rebuild inline indexes task",
+            table.table_id
+        );
+        return Ok(());
+    }
+
     let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
     rebuild_inline_indexes(
         &mut tx_helper,
@@ -71,6 +87,8 @@ async fn rebuild_inline_indexes_from_scratch(
         index_ids,
     )
     .await?;
+
+    tx_helper.delete_task(&task_id).await?;
     tx_helper.commit().await?;
     Ok(())
 }

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -21,7 +21,7 @@ use crate::{
 pub enum TableOptimization {
     CleanupOrphanFiles { last_modified_before: i64 },
     MergeDataFiles { valid_row_threshold: usize },
-    RebuildInlineIndexes { index_ids: Option<Vec<Uuid>> },
+    RebuildInlineIndexes { index_names: Option<Vec<String>> },
 }
 
 pub(crate) async fn process_table_optimization(
@@ -35,7 +35,24 @@ pub(crate) async fn process_table_optimization(
         TableOptimization::MergeDataFiles {
             valid_row_threshold,
         } => merge_data_files(table, valid_row_threshold).await,
-        TableOptimization::RebuildInlineIndexes { index_ids } => {
+        TableOptimization::RebuildInlineIndexes { index_names } => {
+            let index_ids = index_names
+                .as_ref()
+                .map(|names| {
+                    names
+                        .iter()
+                        .map(|name| {
+                            table
+                                .index_manager
+                                .get_index(name)
+                                .map(|def| def.index_id)
+                                .ok_or_else(|| {
+                                    ILError::invalid_input(format!("Index not found: {name}"))
+                                })
+                        })
+                        .collect::<ILResult<Vec<_>>>()
+                })
+                .transpose()?;
             rebuild_inline_indexes_from_scratch(table, index_ids.as_deref()).await
         }
     }

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -13,7 +13,7 @@ use crate::{
     catalog::{DataFileRecord, IndexFileRecord, RowValidity, TransactionHelper},
     index::IndexBuilder,
     storage::{EntryMode, build_parquet_writer, read_data_file_by_record},
-    table::{Table, insert_task},
+    table::{Table, dump::rebuild_inline_indexes, insert_task},
     utils::extract_row_ids_from_record_batch,
 };
 
@@ -21,6 +21,7 @@ use crate::{
 pub enum TableOptimization {
     CleanupOrphanFiles { last_modified_before: i64 },
     MergeDataFiles { valid_row_threshold: usize },
+    RebuildInlineIndexes,
 }
 
 pub(crate) async fn process_table_optimization(
@@ -34,7 +35,22 @@ pub(crate) async fn process_table_optimization(
         TableOptimization::MergeDataFiles {
             valid_row_threshold,
         } => merge_data_files(table, valid_row_threshold).await,
+        TableOptimization::RebuildInlineIndexes => rebuild_inline_indexes_from_scratch(table).await,
     }
+}
+
+async fn rebuild_inline_indexes_from_scratch(table: &Table) -> ILResult<()> {
+    let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
+    rebuild_inline_indexes(
+        &mut tx_helper,
+        &table.table_id,
+        &table.table_schema,
+        &table.index_manager,
+        None,
+    )
+    .await?;
+    tx_helper.commit().await?;
+    Ok(())
 }
 
 async fn cleanup_orphan_files(table: &Table, last_modified_before: i64) -> ILResult<()> {

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -186,3 +186,58 @@ async fn merge_data_files(
 
     Ok(())
 }
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() })]
+#[case(async { catalog_postgres().await }, async { storage_s3().await })]
+#[tokio::test(flavor = "multi_thread")]
+async fn rebuild_inline_indexes(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let client = Client::new(catalog, storage.clone());
+    let table = prepare_simple_testing_table(&client, DataFileFormat::ParquetV2).await?;
+
+    // Insert data without triggering dump so inline indexes exist
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["Alice", "Bob"])),
+            Arc::new(Int32Array::from(vec![30, 25])),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![batch]).with_try_dump(false))
+        .await?;
+
+    // Update to create additional inline index records with validity changes
+    let update = TableUpdate {
+        set_map: HashMap::from([("name".to_string(), lit("Updated"))]),
+        condition: col("age").eq(lit(25)),
+    };
+    table.update(update).await?;
+
+    // Rebuild all inline indexes - should complete without error
+    table
+        .optimize(TableOptimization::RebuildInlineIndexes { index_ids: None })
+        .await?;
+
+    // Verify data is still accessible via scan
+    let table_str = full_table_scan(&table).await?;
+    assert!(
+        !table_str.is_empty(),
+        "Table should not be empty after rebuild"
+    );
+
+    Ok(())
+}

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -229,7 +229,7 @@ async fn rebuild_inline_indexes(
 
     // Rebuild all inline indexes - should complete without error
     table
-        .optimize(TableOptimization::RebuildInlineIndexes { index_ids: None })
+        .optimize(TableOptimization::RebuildInlineIndexes { index_names: None })
         .await?;
 
     // Verify data is still accessible via scan

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -10,13 +10,18 @@ use indexlake::{
     catalog::Catalog,
     expr::{col, lit},
     storage::{DataFileFormat, DirEntry, EntryMode, Storage},
-    table::{TableConfig, TableCreation, TableInsertion, TableOptimization, TableScan, TableUpdate},
+    table::{
+        TableConfig, TableCreation, TableInsertion, TableOptimization, TableScan, TableUpdate,
+    },
 };
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite,
     data::prepare_simple_testing_table,
     init_env_logger, storage_fs, storage_s3,
-    utils::{assert_data_file_count, assert_inline_row_count, full_table_scan, table_scan, timestamp_millis},
+    utils::{
+        assert_data_file_count, assert_inline_row_count, full_table_scan, table_scan,
+        timestamp_millis,
+    },
 };
 
 #[rstest::rstest]
@@ -201,46 +206,75 @@ async fn rebuild_inline_indexes(
 ) -> Result<(), Box<dyn std::error::Error>> {
     init_env_logger();
 
-    let client = Client::new(catalog, storage.clone());
-    let table = prepare_simple_testing_table(&client, DataFileFormat::ParquetV2).await?;
+    let mut client = Client::new(catalog, storage.clone());
+    client.register_index_kind(Arc::new(indexlake_index_btree::BTreeIndexKind));
 
-    // Insert data without triggering dump so inline indexes exist
-    let schema = Arc::new(Schema::new(vec![
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let table_schema = Arc::new(Schema::new(vec![
         Field::new("name", DataType::Utf8, false),
         Field::new("age", DataType::Int32, false),
     ]));
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: TableConfig {
+            preferred_data_file_format: DataFileFormat::ParquetV2,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Create BTree index on age to enable index scan
+    let index_creation = indexlake::table::IndexCreation {
+        name: "idx_age".to_string(),
+        kind: "btree".to_string(),
+        key_columns: vec!["age".to_string()],
+        params: Arc::new(indexlake_index_btree::BTreeIndexParams {}),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(index_creation).await?;
+
+    // Reload table after create_index (takes ownership)
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    // Insert data with try_dump(false) to keep inline rows
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        table_schema.clone(),
         vec![
-            Arc::new(StringArray::from(vec!["Alice", "Bob"])),
-            Arc::new(Int32Array::from(vec![30, 25])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            Arc::new(Int32Array::from(vec![30, 25, 22, 23])),
         ],
     )?;
     table
         .insert(TableInsertion::new(vec![batch]).with_try_dump(false))
         .await?;
 
-    // Update to create additional inline index records with validity changes
+    // Update to create additional inline index records
     let update = TableUpdate {
         set_map: HashMap::from([("name".to_string(), lit("Updated"))]),
         condition: col("age").eq(lit(25)),
     };
     table.update(update).await?;
 
-    // Rebuild all inline indexes - should complete without error
+    // Rebuild all inline indexes
     table
         .optimize(TableOptimization::RebuildInlineIndexes { index_names: None })
         .await?;
 
-    // Verify data via index scan: filter on age triggers BTree index scan
-    // prepare_simple_testing_table creates 4 rows (Alice 20, Bob 21, Charlie 22, David 23)
-    // which get dumped to data files. We added 2 inline rows (Alice 30, Bob 25)
-    // and updated Bob->Updated. Filter age>22 triggers index scan, returning only rows >22.
+    // Verify via index scan: filter on age>22 triggers BTree index scan
     let scan = TableScan::default().with_filters(vec![col("age").gt(lit(22))]);
     let table_str = table_scan(&table, scan).await?;
     assert_eq!(
         table_str,
-        "+---------+-----+\n| name    | age |\n+---------+-----+\n| David   | 23  |\n| Alice   | 30  |\n| Updated | 25  |\n+---------+-----+"
+        "+---------+-----+\n| name    | age |\n+---------+-----+\n| Alice   | 30  |\n| Updated | 25  |\n| David   | 23  |\n+---------+-----+"
     );
 
     Ok(())

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -10,13 +10,13 @@ use indexlake::{
     catalog::Catalog,
     expr::{col, lit},
     storage::{DataFileFormat, DirEntry, EntryMode, Storage},
-    table::{TableConfig, TableCreation, TableInsertion, TableOptimization, TableUpdate},
+    table::{TableConfig, TableCreation, TableInsertion, TableOptimization, TableScan, TableUpdate},
 };
 use indexlake_integration_tests::{
     catalog_postgres, catalog_sqlite,
     data::prepare_simple_testing_table,
     init_env_logger, storage_fs, storage_s3,
-    utils::{assert_data_file_count, assert_inline_row_count, full_table_scan, timestamp_millis},
+    utils::{assert_data_file_count, assert_inline_row_count, full_table_scan, table_scan, timestamp_millis},
 };
 
 #[rstest::rstest]
@@ -232,14 +232,15 @@ async fn rebuild_inline_indexes(
         .optimize(TableOptimization::RebuildInlineIndexes { index_names: None })
         .await?;
 
-    // Verify data is intact after rebuild
-    let table_str = full_table_scan(&table).await?;
+    // Verify data via index scan: filter on age triggers BTree index scan
     // prepare_simple_testing_table creates 4 rows (Alice 20, Bob 21, Charlie 22, David 23)
     // which get dumped to data files. We added 2 inline rows (Alice 30, Bob 25)
-    // and updated Bob->Updated. Rebuild consolidates inline indexes but data files unchanged.
+    // and updated Bob->Updated. Filter age>22 triggers index scan, returning only rows >22.
+    let scan = TableScan::default().with_filters(vec![col("age").gt(lit(22))]);
+    let table_str = table_scan(&table, scan).await?;
     assert_eq!(
         table_str,
-        "+---------+-----+\n| name    | age |\n+---------+-----+\n| Alice   | 20  |\n| Bob     | 21  |\n| Charlie | 22  |\n| David   | 23  |\n| Alice   | 30  |\n| Updated | 25  |\n+---------+-----+"
+        "+---------+-----+\n| name    | age |\n+---------+-----+\n| David   | 23  |\n| Alice   | 30  |\n| Updated | 25  |\n+---------+-----+"
     );
 
     Ok(())

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -232,11 +232,14 @@ async fn rebuild_inline_indexes(
         .optimize(TableOptimization::RebuildInlineIndexes { index_names: None })
         .await?;
 
-    // Verify data is still accessible via scan
+    // Verify data is intact after rebuild
     let table_str = full_table_scan(&table).await?;
-    assert!(
-        !table_str.is_empty(),
-        "Table should not be empty after rebuild"
+    // prepare_simple_testing_table creates 4 rows (Alice 20, Bob 21, Charlie 22, David 23)
+    // which get dumped to data files. We added 2 inline rows (Alice 30, Bob 25)
+    // and updated Bob->Updated. Rebuild consolidates inline indexes but data files unchanged.
+    assert_eq!(
+        table_str,
+        "+---------+-----+\n| name    | age |\n+---------+-----+\n| Alice   | 20  |\n| Bob     | 21  |\n| Charlie | 22  |\n| David   | 23  |\n| Alice   | 30  |\n| Updated | 25  |\n+---------+-----+"
     );
 
     Ok(())


### PR DESCRIPTION
Add `TableOptimization::RebuildInlineIndexes` variant that triggers a full inline index rebuild.

### Usage
```rust
table.optimize(TableOptimization::RebuildInlineIndexes).await?;
```

### What it does
1. Scans all inline rows
2. Builds fresh index segments (all-valid, no invalid rows)
3. Deletes all old inline index records
4. Inserts the new records
5. All in a single transaction

### Verification
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test -p indexlake --lib (9/9)