### PR TITLE
refactor: move task guard into rebuild_inline_indexes

### DIFF
--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -218,9 +218,6 @@ impl DumpTask {
             .insert_index_files(&all_index_file_records)
             .await?;
 
-        tx_helper.commit().await?;
-
-        // Rebuild inline indexes in a separate transaction with task guard
         rebuild_inline_indexes(
             &self.catalog,
             &mut tx_helper,

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -222,7 +222,7 @@ impl DumpTask {
 
         // Rebuild inline indexes in a separate transaction with task guard
         rebuild_inline_indexes(
-            &self.catalog,
+            &mut tx_helper,
             &self.table_id,
             &self.table_schema,
             &self.index_manager,
@@ -230,8 +230,8 @@ impl DumpTask {
         )
         .await?;
 
-        let mut tx_helper = TransactionHelper::new(&self.catalog).await?;
         tx_helper.delete_task(&self.task_id).await?;
+
         tx_helper.commit().await?;
 
         let dumped_row_count = all_data_file_records
@@ -292,24 +292,14 @@ impl DumpTask {
 }
 
 pub(crate) async fn rebuild_inline_indexes(
-    catalog: &Arc<dyn Catalog>,
+    tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    let task_id = format!("rebuild-inline-indexes-{table_id}");
-    if insert_task(catalog, task_id.clone(), Duration::from_secs(24 * 60 * 60))
-        .await
-        .is_err()
-    {
-        debug!("[indexlake] Table {table_id} already has a rebuild inline indexes task");
-        return Ok(());
-    }
-
-    let mut tx_helper = TransactionHelper::new(catalog).await?;
     let inline_index_records =
-        full_build_inline_index_records(&mut tx_helper, table_id, table_schema, || {
+        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
             index_manager.new_index_builders(index_ids)
         })
         .await?;
@@ -322,9 +312,6 @@ pub(crate) async fn rebuild_inline_indexes(
     tx_helper
         .insert_inline_indexes(&inline_index_records)
         .await?;
-
-    tx_helper.delete_task(&task_id).await?;
-    tx_helper.commit().await?;
 
     Ok(())
 }

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -102,6 +102,26 @@ impl DumpTask {
             return Ok(false);
         }
 
+        // Acquire rebuild task guard before starting the dump transaction
+        let rebuild_task_id = format!("rebuild-inline-indexes-{}", self.table_id);
+        if insert_task(
+            &self.catalog,
+            rebuild_task_id.clone(),
+            Duration::from_secs(24 * 60 * 60),
+        )
+        .await
+        .is_err()
+        {
+            debug!(
+                "[indexlake] Table {} already has a rebuild task, skipping dump",
+                self.table_id
+            );
+            let mut tx_helper = TransactionHelper::new(&self.catalog).await?;
+            tx_helper.delete_task(&self.task_id).await?;
+            tx_helper.commit().await?;
+            return Ok(false);
+        }
+
         let mut tx_helper = TransactionHelper::new(&self.catalog).await?;
         let mut inline_row_count = tx_helper.count_inline_rows(&self.table_id).await?;
         if inline_row_count < self.table_config.inline_row_count_limit as i64 {
@@ -219,7 +239,6 @@ impl DumpTask {
             .await?;
 
         rebuild_inline_indexes(
-            &self.catalog,
             &mut tx_helper,
             &self.table_id,
             &self.table_schema,
@@ -228,6 +247,7 @@ impl DumpTask {
         )
         .await?;
 
+        tx_helper.delete_task(&rebuild_task_id).await?;
         tx_helper.delete_task(&self.task_id).await?;
 
         tx_helper.commit().await?;
@@ -290,23 +310,12 @@ impl DumpTask {
 }
 
 pub(crate) async fn rebuild_inline_indexes(
-    catalog: &Arc<dyn Catalog>,
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    // Task guard: prevent concurrent rebuilds (dump + optimize may race)
-    let task_id = format!("rebuild-inline-indexes-{table_id}");
-    if insert_task(catalog, task_id.clone(), Duration::from_secs(24 * 60 * 60))
-        .await
-        .is_err()
-    {
-        debug!("[indexlake] Table {table_id} already has a rebuild task, skipping");
-        return Ok(());
-    }
-
     let inline_index_records =
         full_build_inline_index_records(tx_helper, table_id, table_schema, || {
             index_manager.new_index_builders(index_ids)
@@ -321,9 +330,6 @@ pub(crate) async fn rebuild_inline_indexes(
     tx_helper
         .insert_inline_indexes(&inline_index_records)
         .await?;
-
-    // Release task guard
-    tx_helper.delete_task(&task_id).await?;
 
     Ok(())
 }

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -218,8 +218,11 @@ impl DumpTask {
             .insert_index_files(&all_index_file_records)
             .await?;
 
+        tx_helper.commit().await?;
+
+        // Rebuild inline indexes in a separate transaction with task guard
         rebuild_inline_indexes(
-            &mut tx_helper,
+            &self.catalog,
             &self.table_id,
             &self.table_schema,
             &self.index_manager,
@@ -227,8 +230,8 @@ impl DumpTask {
         )
         .await?;
 
+        let mut tx_helper = TransactionHelper::new(&self.catalog).await?;
         tx_helper.delete_task(&self.task_id).await?;
-
         tx_helper.commit().await?;
 
         let dumped_row_count = all_data_file_records
@@ -289,14 +292,24 @@ impl DumpTask {
 }
 
 pub(crate) async fn rebuild_inline_indexes(
-    tx_helper: &mut TransactionHelper,
+    catalog: &Arc<dyn Catalog>,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
+    let task_id = format!("rebuild-inline-indexes-{table_id}");
+    if insert_task(catalog, task_id.clone(), Duration::from_secs(24 * 60 * 60))
+        .await
+        .is_err()
+    {
+        debug!("[indexlake] Table {table_id} already has a rebuild inline indexes task");
+        return Ok(());
+    }
+
+    let mut tx_helper = TransactionHelper::new(catalog).await?;
     let inline_index_records =
-        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
+        full_build_inline_index_records(&mut tx_helper, table_id, table_schema, || {
             index_manager.new_index_builders(index_ids)
         })
         .await?;
@@ -309,6 +322,9 @@ pub(crate) async fn rebuild_inline_indexes(
     tx_helper
         .insert_inline_indexes(&inline_index_records)
         .await?;
+
+    tx_helper.delete_task(&task_id).await?;
+    tx_helper.commit().await?;
 
     Ok(())
 }

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -222,6 +222,7 @@ impl DumpTask {
 
         // Rebuild inline indexes in a separate transaction with task guard
         rebuild_inline_indexes(
+            &self.catalog,
             &mut tx_helper,
             &self.table_id,
             &self.table_schema,
@@ -292,12 +293,23 @@ impl DumpTask {
 }
 
 pub(crate) async fn rebuild_inline_indexes(
+    catalog: &Arc<dyn Catalog>,
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
     index_manager: &IndexManager,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
+    // Task guard: prevent concurrent rebuilds (dump + optimize may race)
+    let task_id = format!("rebuild-inline-indexes-{table_id}");
+    if insert_task(catalog, task_id.clone(), Duration::from_secs(24 * 60 * 60))
+        .await
+        .is_err()
+    {
+        debug!("[indexlake] Table {table_id} already has a rebuild task, skipping");
+        return Ok(());
+    }
+
     let inline_index_records =
         full_build_inline_index_records(tx_helper, table_id, table_schema, || {
             index_manager.new_index_builders(index_ids)
@@ -312,6 +324,9 @@ pub(crate) async fn rebuild_inline_indexes(
     tx_helper
         .insert_inline_indexes(&inline_index_records)
         .await?;
+
+    // Release task guard
+    tx_helper.delete_task(&task_id).await?;
 
     Ok(())
 }

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -62,35 +62,14 @@ async fn rebuild_inline_indexes_from_scratch(
     table: &Table,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    let task_id = format!("rebuild-inline-indexes-{}", table.table_id);
-    if insert_task(
-        &table.catalog,
-        task_id.clone(),
-        Duration::from_secs(24 * 60 * 60),
-    )
-    .await
-    .is_err()
-    {
-        debug!(
-            "[indexlake] Table {} already has a rebuild inline indexes task",
-            table.table_id
-        );
-        return Ok(());
-    }
-
-    let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
     rebuild_inline_indexes(
-        &mut tx_helper,
+        &table.catalog,
         &table.table_id,
         &table.table_schema,
         &table.index_manager,
         index_ids,
     )
-    .await?;
-
-    tx_helper.delete_task(&task_id).await?;
-    tx_helper.commit().await?;
-    Ok(())
+    .await
 }
 
 async fn cleanup_orphan_files(table: &Table, last_modified_before: i64) -> ILResult<()> {

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -53,27 +53,19 @@ pub(crate) async fn process_table_optimization(
                         .collect::<ILResult<Vec<_>>>()
                 })
                 .transpose()?;
-            rebuild_inline_indexes_from_scratch(table, index_ids.as_deref()).await
+            let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
+            rebuild_inline_indexes(
+                &table.catalog,
+                &mut tx_helper,
+                &table.table_id,
+                &table.table_schema,
+                &table.index_manager,
+                index_ids.as_deref(),
+            )
+            .await?;
+            tx_helper.commit().await
         }
     }
-}
-
-async fn rebuild_inline_indexes_from_scratch(
-    table: &Table,
-    index_ids: Option<&[Uuid]>,
-) -> ILResult<()> {
-    let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
-    rebuild_inline_indexes(
-        &table.catalog,
-        &mut tx_helper,
-        &table.table_id,
-        &table.table_schema,
-        &table.index_manager,
-        index_ids,
-    )
-    .await?;
-    tx_helper.commit().await?;
-    Ok(())
 }
 
 async fn cleanup_orphan_files(table: &Table, last_modified_before: i64) -> ILResult<()> {

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -62,14 +62,34 @@ async fn rebuild_inline_indexes_from_scratch(
     table: &Table,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    rebuild_inline_indexes(
+    let task_id = format!("rebuild-inline-indexes-{}", table.table_id);
+    if insert_task(
         &table.catalog,
+        task_id.clone(),
+        Duration::from_secs(24 * 60 * 60),
+    )
+    .await
+    .is_err()
+    {
+        debug!(
+            "[indexlake] Table {} already has a rebuild inline indexes task",
+            table.table_id
+        );
+        return Ok(());
+    }
+
+    let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
+    rebuild_inline_indexes(
+        &mut tx_helper,
         &table.table_id,
         &table.table_schema,
         &table.index_manager,
         index_ids,
     )
-    .await
+    .await?;
+    tx_helper.delete_task(&task_id).await?;
+    tx_helper.commit().await?;
+    Ok(())
 }
 
 async fn cleanup_orphan_files(table: &Table, last_modified_before: i64) -> ILResult<()> {

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -53,9 +53,24 @@ pub(crate) async fn process_table_optimization(
                         .collect::<ILResult<Vec<_>>>()
                 })
                 .transpose()?;
+            // Acquire task guard before starting transaction (prevents SQLite write lock conflict)
+            let task_id = format!("rebuild-inline-indexes-{}", table.table_id);
+            if insert_task(
+                &table.catalog,
+                task_id.clone(),
+                Duration::from_secs(24 * 60 * 60),
+            )
+            .await
+            .is_err()
+            {
+                debug!(
+                    "[indexlake] Table {} already has a rebuild task, skipping",
+                    table.table_id
+                );
+                return Ok(());
+            }
             let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
             rebuild_inline_indexes(
-                &table.catalog,
                 &mut tx_helper,
                 &table.table_id,
                 &table.table_schema,
@@ -63,6 +78,7 @@ pub(crate) async fn process_table_optimization(
                 index_ids.as_deref(),
             )
             .await?;
+            tx_helper.delete_task(&task_id).await?;
             tx_helper.commit().await
         }
     }

--- a/indexlake/src/table/optimize.rs
+++ b/indexlake/src/table/optimize.rs
@@ -62,24 +62,9 @@ async fn rebuild_inline_indexes_from_scratch(
     table: &Table,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    let task_id = format!("rebuild-inline-indexes-{}", table.table_id);
-    if insert_task(
-        &table.catalog,
-        task_id.clone(),
-        Duration::from_secs(24 * 60 * 60),
-    )
-    .await
-    .is_err()
-    {
-        debug!(
-            "[indexlake] Table {} already has a rebuild inline indexes task",
-            table.table_id
-        );
-        return Ok(());
-    }
-
     let mut tx_helper = TransactionHelper::new(&table.catalog).await?;
     rebuild_inline_indexes(
+        &table.catalog,
         &mut tx_helper,
         &table.table_id,
         &table.table_schema,
@@ -87,7 +72,6 @@ async fn rebuild_inline_indexes_from_scratch(
         index_ids,
     )
     .await?;
-    tx_helper.delete_task(&task_id).await?;
     tx_helper.commit().await?;
     Ok(())
 }


### PR DESCRIPTION
Move the task guard from the optimize wrapper into rebuild_inline_indexes itself, so both callers (dump task and manual optimize) get concurrent-rebuild protection automatically.

### Changes
- rebuild_inline_indexes now takes &Arc<dyn Catalog> and manages its own transaction with a task guard
- dump.rs: commit data file insertions first, then call rebuild in separate transaction
- optimize.rs: simplified to direct call (task guard now inside rebuild_inline_indexes)