### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-benchmarks"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-catalog-postgres"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-catalog-sqlite"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-datafusion"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2751,14 +2751,14 @@ dependencies = [
 
 [[package]]
 name = "indexlake-datafusion-gen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prost-build",
 ]
 
 [[package]]
 name = "indexlake-examples"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "indexlake",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-bm25"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-btree"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-hnsw"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-rabitq"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-rstar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-integration-tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "bytes",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-storage-fs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-storage-s3"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 homepage = "https://github.com/systemxlabs/indexlake"
 license = "MIT"
@@ -27,18 +27,18 @@ repository = "https://github.com/systemxlabs/indexlake"
 rust-version = "1.89.0"
 
 [workspace.dependencies]
-indexlake = { path = "indexlake", version = "0.4.0" }
-indexlake-catalog-postgres = { path = "catalogs/postgres", version = "0.4.0" }
-indexlake-catalog-sqlite = { path = "catalogs/sqlite", version = "0.4.0" }
-indexlake-datafusion = { path = "integrations/datafusion", version = "0.4.0" }
-indexlake-index-bm25 = { path = "indexes/bm25", version = "0.4.0" }
-indexlake-index-btree = { path = "indexes/btree", version = "0.4.0" }
-indexlake-index-hnsw = { path = "indexes/hnsw", version = "0.4.0" }
-indexlake-index-rabitq = { path = "indexes/rabitq", version = "0.4.0" }
-indexlake-index-rstar = { path = "indexes/rstar", version = "0.4.0" }
-indexlake-integration-tests = { path = "integration-tests", version = "0.4.0" }
-indexlake-storage-fs = { path = "storages/fs", version = "0.4.0" }
-indexlake-storage-s3 = { path = "storages/s3", version = "0.4.0" }
+indexlake = { path = "indexlake", version = "0.5.0" }
+indexlake-catalog-postgres = { path = "catalogs/postgres", version = "0.5.0" }
+indexlake-catalog-sqlite = { path = "catalogs/sqlite", version = "0.5.0" }
+indexlake-datafusion = { path = "integrations/datafusion", version = "0.5.0" }
+indexlake-index-bm25 = { path = "indexes/bm25", version = "0.5.0" }
+indexlake-index-btree = { path = "indexes/btree", version = "0.5.0" }
+indexlake-index-hnsw = { path = "indexes/hnsw", version = "0.5.0" }
+indexlake-index-rabitq = { path = "indexes/rabitq", version = "0.5.0" }
+indexlake-index-rstar = { path = "indexes/rstar", version = "0.5.0" }
+indexlake-integration-tests = { path = "integration-tests", version = "0.5.0" }
+indexlake-storage-fs = { path = "storages/fs", version = "0.5.0" }
+indexlake-storage-s3 = { path = "storages/s3", version = "0.5.0" }
 
 arrow = "58"
 arrow-schema = "58"


### PR DESCRIPTION
Bump workspace version from 0.4.0 to 0.5.0.