### PR TITLE
feat: impl From<ILError> for DataFusionError and simplify error conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "comfy-table",
+ "datafusion-common",
  "derive-visitor",
  "derive-with",
  "futures",

--- a/indexlake/Cargo.toml
+++ b/indexlake/Cargo.toml
@@ -24,6 +24,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4", "v7"] }
+datafusion-common = { workspace = true, optional = true }
+
+[features]
+datafusion = ["datafusion-common"]
 
 [lib]
 doctest = false

--- a/indexlake/src/error.rs
+++ b/indexlake/src/error.rs
@@ -90,3 +90,10 @@ impl From<uuid::Error> for ILError {
         ILError::InternalError(format!("UUID error: {err}"), Location::caller())
     }
 }
+
+#[cfg(feature = "datafusion")]
+impl From<ILError> for datafusion_common::DataFusionError {
+    fn from(err: ILError) -> Self {
+        datafusion_common::DataFusionError::External(Box::new(err))
+    }
+}

--- a/integrations/datafusion/Cargo.toml
+++ b/integrations/datafusion/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 description = "IndexLake datafusion integration"
 
 [dependencies]
-indexlake = { workspace = true }
+indexlake = { workspace = true, features = ["datafusion"] }
 
 # Core DataFusion components (instead of full datafusion crate)
 arrow = { workspace = true }

--- a/integrations/datafusion/src/delete.rs
+++ b/integrations/datafusion/src/delete.rs
@@ -78,15 +78,9 @@ impl ExecutionPlan for IndexLakeDeleteExec {
         let condition = self.condition.clone();
 
         let stream = futures::stream::once(async move {
-            let table = lazy_table
-                .get_or_load()
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let table = lazy_table.get_or_load().await?;
 
-            let count = table
-                .delete(condition)
-                .await
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            let count = table.delete(condition).await?;
 
             make_result_batch(count as i64)
         })

--- a/integrations/datafusion/src/insert.rs
+++ b/integrations/datafusion/src/insert.rs
@@ -112,18 +112,12 @@ impl ExecutionPlan for IndexLakeInsertExec {
         let bypass_insert_threshold = self.bypass_insert_threshold;
 
         let stream = futures::stream::once(async move {
-            let table = lazy_table
-                .get_or_load()
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let table = lazy_table.get_or_load().await?;
 
             match insert_op {
                 InsertOp::Append => {}
                 InsertOp::Overwrite => {
-                    table
-                        .truncate()
-                        .await
-                        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                    table.truncate().await?;
                 }
                 InsertOp::Replace => {
                     return Err(DataFusionError::Execution(
@@ -143,11 +137,7 @@ impl ExecutionPlan for IndexLakeInsertExec {
                             ))
                         })
                         .boxed();
-                    let count = table.bypass_insert(stream).await.map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to bypass insert into indexlake: {e}"
-                        ))
-                    })?;
+                    let count = table.bypass_insert(stream).await?;
                     make_result_batch(count as i64)
                 }
                 _ => {
@@ -158,15 +148,13 @@ impl ExecutionPlan for IndexLakeInsertExec {
 
                         table
                             .insert(TableInsertion::new(vec![batch]).with_try_dump(false))
-                            .await
-                            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                            .await?;
                     }
 
                     // trigger dump
                     table
                         .insert(TableInsertion::new(vec![]).with_try_dump(true))
-                        .await
-                        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                        .await?;
 
                     make_result_batch(count)
                 }

--- a/integrations/datafusion/src/scan.rs
+++ b/integrations/datafusion/src/scan.rs
@@ -148,10 +148,7 @@ impl ExecutionPlan for IndexLakeScanExec {
         let lazy_table = self.lazy_table.clone();
 
         let fut = async move {
-            let table = lazy_table
-                .get_or_load()
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let table = lazy_table.get_or_load().await?;
             get_batch_stream(table, projected_schema.clone(), scan).await
         };
         let stream = futures::stream::once(fut).try_flatten();
@@ -297,10 +294,7 @@ async fn get_batch_stream(
 ) -> Result<SendableRecordBatchStream, DataFusionError> {
     let stream = if scan.projection == Some(Vec::new()) {
         scan.projection = Some(vec![0]);
-        let stream = table
-            .scan(scan)
-            .await
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+        let stream = table.scan(scan).await?;
         stream
             .map(|batch| {
                 let batch = batch?;
@@ -311,12 +305,9 @@ async fn get_batch_stream(
             })
             .boxed()
     } else {
-        table
-            .scan(scan)
-            .await
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?
+        table.scan(scan).await?
     };
-    let stream = stream.map_err(|e| DataFusionError::Execution(e.to_string()));
+    let stream = stream.map_err(DataFusionError::from);
     Ok(Box::pin(RecordBatchStreamAdapter::new(
         projected_schema,
         stream,

--- a/integrations/datafusion/src/search.rs
+++ b/integrations/datafusion/src/search.rs
@@ -94,10 +94,7 @@ impl ExecutionPlan for IndexLakeSearchExec {
         let projection = self.projection.clone();
 
         let fut = async move {
-            let table = lazy_table
-                .get_or_load()
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let table = lazy_table.get_or_load().await?;
 
             let search = TableSearch {
                 query,
@@ -105,11 +102,8 @@ impl ExecutionPlan for IndexLakeSearchExec {
                 dynamic_fields: dynamic_fields.clone(),
             };
 
-            let stream = table
-                .search(search)
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            let stream = stream.map_err(|e| DataFusionError::External(Box::new(e)));
+            let stream = table.search(search).await?;
+            let stream = stream.map_err(DataFusionError::from);
             Ok::<_, DataFusionError>(stream)
         };
 

--- a/integrations/datafusion/src/table.rs
+++ b/integrations/datafusion/src/table.rs
@@ -60,8 +60,7 @@ impl IndexLakeTable {
         let counts = self
             .table
             .count(&[TableScanPartition::single_partition()])
-            .await
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+            .await?;
         self.table_row_count = Some(counts[0]);
         Ok(self)
     }
@@ -116,19 +115,11 @@ impl TableProvider for IndexLakeTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let data_file_count = self
-            .table
-            .data_file_count()
-            .await
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+        let data_file_count = self.table.data_file_count().await?;
         let data_files = if data_file_count > 1000 {
             None
         } else {
-            let records = self
-                .table
-                .data_file_records()
-                .await
-                .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+            let records = self.table.data_file_records().await?;
             Some(Arc::new(records))
         };
 
@@ -148,11 +139,7 @@ impl TableProvider for IndexLakeTable {
         .with_table(self.table.clone());
 
         let scan_partitions = Arc::new(build_scan_partitions(self.num_scan_partitions, data_files));
-        let partition_row_counts = self
-            .table
-            .count(scan_partitions.as_ref())
-            .await
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+        let partition_row_counts = self.table.count(scan_partitions.as_ref()).await?;
         let partition_row_counts = Arc::new(partition_row_counts);
         let exec = IndexLakeScanExec::try_new(
             lazy_table,
@@ -178,10 +165,7 @@ impl TableProvider for IndexLakeTable {
                 supports.push(TableProviderFilterPushDown::Unsupported);
                 continue;
             };
-            let support = self
-                .table
-                .supports_filter(il_expr.clone())
-                .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+            let support = self.table.supports_filter(il_expr.clone())?;
             match support {
                 FilterSupport::Exact => supports.push(TableProviderFilterPushDown::Exact),
                 FilterSupport::Inexact => supports.push(TableProviderFilterPushDown::Inexact),

--- a/integrations/datafusion/src/update.rs
+++ b/integrations/datafusion/src/update.rs
@@ -79,15 +79,9 @@ impl ExecutionPlan for IndexLakeUpdateExec {
         };
 
         let stream = futures::stream::once(async move {
-            let table = lazy_table
-                .get_or_load()
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let table = lazy_table.get_or_load().await?;
 
-            let count = table
-                .update(update)
-                .await
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            let count = table.update(update).await?;
 
             make_result_batch(count as i64)
         })


### PR DESCRIPTION
## Summary

Add `From<ILError> for DataFusionError` behind an optional `datafusion` feature flag in the `indexlake` core crate, and simplify error conversion across the datafusion integration crate.

## Changes

### `indexlake` core crate
- Add `datafusion-common` as an optional dependency behind a `datafusion` feature
- Implement `From<ILError> for DataFusionError`, mapping to `DataFusionError::External(Box::new(err))` to preserve the original error chain

### `indexlake-datafusion` integration crate
- Enable the `indexlake/datafusion` feature
- Replace 3 different ad-hoc `.map_err()` patterns with direct `?` operator:

| Before | After |
|--------|-------|
| `.map_err(\|e\| DataFusionError::External(Box::new(e)))?` | `?` |
| `.map_err(\|e\| DataFusionError::Execution(e.to_string()))?` | `?` |
| `.map_err(\|e\| DataFusionError::Internal(e.to_string()))?` | `?` |

- Stream `.map_err()` now uses `DataFusionError::from` instead of ad-hoc closures

## Verification
- ✅ Full workspace build
- ✅ `indexlake` tests (9 passed)
- ✅ `indexlake-datafusion` tests (2 passed)
- ✅ Integration tests (15 passed)
- ✅ Clippy (no warnings)