### PR TITLE
refactor: move limit from SearchQuery to TableSearch

### DIFF
--- a/benchmarks/src/bin/indexlake_bm25.rs
+++ b/benchmarks/src/bin/indexlake_bm25.rs
@@ -102,10 +102,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table_search = TableSearch {
         query: Arc::new(BM25SearchQuery {
             query: "杨绛女士".to_string(),
-            limit: Some(limit),
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(limit),
         concurrency: 8,
     };
     let mut stream = table.search(table_search).await?;

--- a/benchmarks/src/bin/indexlake_hnsw.rs
+++ b/benchmarks/src/bin/indexlake_hnsw.rs
@@ -103,10 +103,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table_search = TableSearch {
         query: Arc::new(HnswSearchQuery {
             vector: vec![500.0; 1024],
-            limit,
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(limit),
         concurrency: 8,
     };
     let mut stream = table.search(table_search).await?;

--- a/benchmarks/src/bin/indexlake_rabitq.rs
+++ b/benchmarks/src/bin/indexlake_rabitq.rs
@@ -101,10 +101,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table_search = TableSearch {
         query: Arc::new(RabitqSearchQuery {
             vector: vec![500.0; 1024],
-            limit,
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(limit),
         concurrency: 8,
     };
     let mut stream = table.search(table_search).await?;

--- a/indexes/bm25/src/index.rs
+++ b/indexes/bm25/src/index.rs
@@ -15,16 +15,11 @@ use crate::{ArrowScorer, BM25IndexParams, JiebaTokenizer};
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BM25SearchQuery {
     pub query: String,
-    pub limit: Option<usize>,
 }
 
 impl SearchQuery for BM25SearchQuery {
     fn index_kind(&self) -> &str {
         "bm25"
-    }
-
-    fn limit(&self) -> Option<usize> {
-        self.limit
     }
 }
 
@@ -64,14 +59,13 @@ impl Index for BM25Index {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
         validity: &RowValidity,
+        limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries> {
         let query = query
             .downcast_ref::<BM25SearchQuery>()
             .ok_or(ILError::index("Invalid query type"))?;
         let query_embedding = self.embedder.embed(&query.query);
-        let matches = self
-            .scorer
-            .matches(&query_embedding, query.limit, validity)?;
+        let matches = self.scorer.matches(&query_embedding, limit, validity)?;
 
         let mut row_ids = Vec::with_capacity(matches.len());
         let mut scores = Vec::with_capacity(matches.len());

--- a/indexes/btree/src/index.rs
+++ b/indexes/btree/src/index.rs
@@ -123,6 +123,7 @@ impl Index for BTreeIndex {
         _query: &dyn SearchQuery,
         _dynamic_fields: &[String],
         _validity: &indexlake::index::RowValidity,
+        _limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "B-tree index does not support search",

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -17,16 +17,11 @@ use crate::Euclidean;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HnswSearchQuery {
     pub vector: Vec<f32>,
-    pub limit: usize,
 }
 
 impl SearchQuery for HnswSearchQuery {
     fn index_kind(&self) -> &str {
         "hnsw"
-    }
-
-    fn limit(&self) -> Option<usize> {
-        Some(self.limit)
     }
 }
 
@@ -76,6 +71,7 @@ impl Index for HnswIndex {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
         validity: &RowValidity,
+        limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries> {
         let query = query.downcast_ref::<HnswSearchQuery>().ok_or_else(|| {
             ILError::index(format!(
@@ -83,19 +79,20 @@ impl Index for HnswIndex {
             ))
         })?;
 
+        let limit = limit.unwrap_or(usize::MAX);
         // Keep fetching until we get enough valid rows or exhaust the index
         let mut row_ids = Vec::new();
         let mut scores = Vec::new();
         let total = self.hnsw.len();
-        let mut fetch_limit = query.limit.min(total);
+        let mut fetch_limit = limit.min(total);
         let mut scanned_count = 0;
-        while row_ids.len() < query.limit && fetch_limit <= total {
+        while row_ids.len() < limit && fetch_limit <= total {
             let neighbors = self.hnsw.knn(&query.vector, fetch_limit);
             for neighbor in &neighbors[scanned_count..] {
                 if validity.is_valid(neighbor.index)? {
                     row_ids.push(self.row_ids[neighbor.index]);
                     scores.push(neighbor.distance as f64);
-                    if row_ids.len() >= query.limit {
+                    if row_ids.len() >= limit {
                         break;
                     }
                 }

--- a/indexes/rabitq/src/index.rs
+++ b/indexes/rabitq/src/index.rs
@@ -15,22 +15,17 @@ use crate::rabitq::{BruteForceRabitqIndex, BruteForceSearchParams};
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RabitqSearchQuery {
     pub vector: Vec<f32>,
-    pub limit: usize,
 }
 
 impl RabitqSearchQuery {
-    pub fn new(vector: Vec<f32>, limit: usize) -> Self {
-        Self { vector, limit }
+    pub fn new(vector: Vec<f32>) -> Self {
+        Self { vector }
     }
 }
 
 impl SearchQuery for RabitqSearchQuery {
     fn index_kind(&self) -> &str {
         "rabitq"
-    }
-
-    fn limit(&self) -> Option<usize> {
-        Some(self.limit)
     }
 }
 
@@ -79,6 +74,7 @@ impl Index for RabitqIndex {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
         validity: &RowValidity,
+        limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries> {
         let query = query.downcast_ref::<RabitqSearchQuery>().ok_or_else(|| {
             ILError::index(format!(
@@ -86,15 +82,16 @@ impl Index for RabitqIndex {
             ))
         })?;
 
+        let limit = limit.unwrap_or(usize::MAX);
         let score_higher_is_better = matches!(self.metric, RabitqMetric::InnerProduct);
 
         // Keep fetching until we get enough valid rows or exhaust the index
         let mut row_ids = Vec::new();
         let mut scores = Vec::new();
         let total_vectors = self.row_ids.len();
-        let mut fetch_limit = query.limit.min(total_vectors);
+        let mut fetch_limit = limit.min(total_vectors);
         let mut scanned_count = 0;
-        while row_ids.len() < query.limit && fetch_limit <= total_vectors {
+        while row_ids.len() < limit && fetch_limit <= total_vectors {
             let params = BruteForceSearchParams { top_k: fetch_limit };
             let results = self
                 .inner
@@ -104,7 +101,7 @@ impl Index for RabitqIndex {
                 if validity.is_valid(r.id)? {
                     row_ids.push(self.row_ids[r.id]);
                     scores.push(r.score as f64);
-                    if row_ids.len() >= query.limit {
+                    if row_ids.len() >= limit {
                         break;
                     }
                 }

--- a/indexes/rstar/src/index.rs
+++ b/indexes/rstar/src/index.rs
@@ -40,6 +40,7 @@ impl Index for RStarIndex {
         _query: &dyn SearchQuery,
         _dynamic_fields: &[String],
         _validity: &indexlake::index::RowValidity,
+        _limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries> {
         Err(ILError::not_supported(
             "RStar index does not support search",

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -72,6 +72,7 @@ pub trait Index: Debug + Send + Sync {
         query: &dyn SearchQuery,
         dynamic_fields: &[String],
         validity: &RowValidity,
+        limit: Option<usize>,
     ) -> ILResult<SearchIndexEntries>;
 
     async fn filter(
@@ -109,8 +110,6 @@ pub enum FilterSupport {
 
 pub trait SearchQuery: Debug + Send + Sync + Any {
     fn index_kind(&self) -> &str;
-
-    fn limit(&self) -> Option<usize>;
 }
 
 /// Codec for serializing/deserializing SearchQuery to/from bytes.

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -23,6 +23,7 @@ pub struct TableSearch {
     pub query: Arc<dyn SearchQuery>,
     pub projection: Option<Vec<usize>>,
     pub dynamic_fields: Vec<String>,
+    pub limit: Option<usize>,
     /// Maximum number of concurrent data file index searches and row reads.
     pub concurrency: usize,
 }
@@ -152,6 +153,7 @@ pub(crate) async fn process_search(
             let index_kind = index_kind.clone();
             let index_def = index_def.clone();
             let search_query = search.query.clone();
+            let search_limit = search.limit;
             let dynamic_fields = search.dynamic_fields.clone();
             let validity = data_file_record.validity.clone();
             async move {
@@ -164,6 +166,7 @@ pub(crate) async fn process_search(
                     &index_file_record,
                     &dynamic_fields,
                     &validity,
+                    search_limit,
                 )
                 .await?;
                 Ok::<_, ILError>((data_file_id, search_entries))
@@ -183,11 +186,8 @@ pub(crate) async fn process_search(
     let score_higher_is_better = inline_search_entries.score_higher_is_better;
     all_search_entries.push((RowLocation::Inline, inline_search_entries));
 
-    let merged_entries = merge_search_index_entries(
-        all_search_entries,
-        score_higher_is_better,
-        search.query.limit(),
-    )?;
+    let merged_entries =
+        merge_search_index_entries(all_search_entries, score_higher_is_better, search.limit)?;
 
     // Determine if user explicitly requested _row_id in their projection
     let user_wants_row_id = search
@@ -260,6 +260,7 @@ async fn search_inline_rows(
                 search.query.as_ref(),
                 &search.dynamic_fields,
                 &record.validity,
+                search.limit,
             )
             .await?;
         score_higher_is_better = entries.score_higher_is_better;
@@ -293,6 +294,7 @@ async fn search_index_file(
     index_file_record: &IndexFileRecord,
     dynamic_fields: &[String],
     validity: &RowValidity,
+    limit: Option<usize>,
 ) -> ILResult<SearchIndexEntries> {
     let index_file = storage.open(&index_file_record.relative_path).await?;
 
@@ -301,7 +303,9 @@ async fn search_index_file(
 
     let index = index_builder.build()?;
 
-    let search_index_entries = index.search(search_query, dynamic_fields, validity).await?;
+    let search_index_entries = index
+        .search(search_query, dynamic_fields, validity, limit)
+        .await?;
 
     Ok(search_index_entries)
 }

--- a/indexlake/src/table/search.rs
+++ b/indexlake/src/table/search.rs
@@ -286,6 +286,7 @@ async fn search_inline_rows(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn search_index_file(
     storage: &dyn Storage,
     index_kind: &dyn IndexKind,

--- a/integration-tests/tests/datafusion.rs
+++ b/integration-tests/tests/datafusion.rs
@@ -822,7 +822,6 @@ async fn datafusion_search_exec(
     // Use BM25 search to find "Rust" documents
     let query = Arc::new(indexlake_index_bm25::BM25SearchQuery {
         query: "Rust".to_string(),
-        limit: Some(2),
     });
     let dynamic_fields = vec!["score".to_string()];
 
@@ -921,7 +920,6 @@ async fn datafusion_search_exec_serialization(
 
     let query = Arc::new(indexlake_index_bm25::BM25SearchQuery {
         query: "Rust".to_string(),
-        limit: Some(1),
     });
     let dynamic_fields = vec!["score".to_string()];
 

--- a/integration-tests/tests/index_bm25.rs
+++ b/integration-tests/tests/index_bm25.rs
@@ -100,10 +100,10 @@ async fn create_bm25_index(
     let mut search = TableSearch {
         query: Arc::new(BM25SearchQuery {
             query: "pink".to_string(),
-            limit: Some(2),
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(2),
         concurrency: 8,
     };
     let table_str = table_search(&table, search.clone()).await?;
@@ -135,10 +135,10 @@ async fn create_bm25_index(
     let mut search = TableSearch {
         query: Arc::new(BM25SearchQuery {
             query: "大学".to_string(),
-            limit: Some(2),
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(2),
         concurrency: 8,
     };
     let table_str = table_search(&table, search.clone()).await?;
@@ -170,10 +170,10 @@ async fn create_bm25_index(
     let search_without_row_id = TableSearch {
         query: Arc::new(BM25SearchQuery {
             query: "pink".to_string(),
-            limit: Some(2),
         }),
         projection: Some(vec![1]),
         dynamic_fields: vec![],
+        limit: Some(2),
         concurrency: 8,
     };
     let table_str = table_search(&table, search_without_row_id).await?;

--- a/integration-tests/tests/index_hnsw.rs
+++ b/integration-tests/tests/index_hnsw.rs
@@ -51,10 +51,10 @@ async fn create_hnsw_index(
     let mut search = TableSearch {
         query: Arc::new(HnswSearchQuery {
             vector: vec![26.0, 26.0, 26.0],
-            limit: 2,
         }),
         projection: None,
         dynamic_fields: vec![],
+        limit: Some(2),
         concurrency: 8,
     };
 

--- a/integrations/datafusion/src/codec.rs
+++ b/integrations/datafusion/src/codec.rs
@@ -247,7 +247,7 @@ impl PhysicalExtensionCodec for IndexLakePhysicalCodec {
                         namespace_name: exec.lazy_table.namespace_name.clone(),
                         table_name: exec.lazy_table.table_name.clone(),
                         index_kind: exec.query.index_kind().to_string(),
-                        limit: exec.query.limit().map(|l| l as u32),
+                        limit: exec.limit.map(|l| l as u32),
                         dynamic_fields: exec.dynamic_fields.clone(),
                         projection,
                         schema: Some(schema),

--- a/integrations/datafusion/src/search.rs
+++ b/integrations/datafusion/src/search.rs
@@ -23,6 +23,7 @@ pub struct IndexLakeSearchExec {
     pub query: Arc<dyn SearchQuery>,
     pub dynamic_fields: Vec<String>,
     pub projection: Option<Vec<usize>>,
+    pub limit: Option<usize>,
     properties: Arc<PlanProperties>,
 }
 
@@ -49,6 +50,7 @@ impl IndexLakeSearchExec {
             query,
             dynamic_fields,
             projection,
+            limit: None,
             properties,
         })
     }
@@ -93,6 +95,7 @@ impl ExecutionPlan for IndexLakeSearchExec {
         let query = self.query.clone();
         let dynamic_fields = self.dynamic_fields.clone();
         let projection = self.projection.clone();
+        let limit = self.limit;
 
         let fut = async move {
             let table = lazy_table.get_or_load().await?;
@@ -101,6 +104,7 @@ impl ExecutionPlan for IndexLakeSearchExec {
                 query,
                 projection: projection.clone(),
                 dynamic_fields: dynamic_fields.clone(),
+                limit,
                 concurrency: 8,
             };
 
@@ -117,7 +121,7 @@ impl ExecutionPlan for IndexLakeSearchExec {
     }
 
     fn fetch(&self) -> Option<usize> {
-        self.query.limit()
+        self.limit
     }
 
     fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
@@ -142,7 +146,7 @@ impl DisplayAs for IndexLakeSearchExec {
         if let Some(ref projection) = self.projection {
             write!(f, ", projection={projection:?}")?;
         }
-        if let Some(limit) = self.query.limit() {
+        if let Some(limit) = self.limit {
             write!(f, ", limit={limit}")?;
         }
         Ok(())


### PR DESCRIPTION
## Summary

Move `limit` out of `SearchQuery` trait/structs and into `TableSearch`. `limit` is a paging/execution parameter, not part of search semantics.

## Changes

### Trait & implementations
- `SearchQuery`: remove `fn limit(&self) -> Option\<usize\>` method
- `BM25SearchQuery`, `HnswSearchQuery`, `RabitqSearchQuery`: remove `limit` field
- `Index::search()`: add `limit: Option\<usize\>` parameter
- 5 index implementations updated (bm25, hnsw, rabitq, btree, rstar)

### TableSearch
- Add `limit: Option\<usize\>` field
- `process_search()`: use `search.limit` instead of `search.query.limit()`
- `search_index_file()`: pass `limit` to `Index::search()`

### DataFusion integration
- `IndexLakeSearchExec`: add `limit` field, set via proto/codec
- `codec.rs`: serialize/deserialize `exec.limit` (proto already had the field)
- `fetch()`, `DisplayAs`, `execute()`: use `self.limit`

### Construction sites (10 sites)
- 3 benchmarks, 4 integration tests, 2 datafusion tests, 1 datafusion search exec

## Verification
- ✅ Build (all targets)
- ✅ Clippy (only pre-existing "too many arguments" warning)
- ✅ fmt
- ✅ `datafusion_search_exec::case_1` test pass