### PR TITLE
feat: add limit param to IndexLakeSearchExec::try_new and implement with_fetch

### DIFF
--- a/integration-tests/tests/datafusion.rs
+++ b/integration-tests/tests/datafusion.rs
@@ -831,7 +831,14 @@ async fn datafusion_search_exec(
 
     let lazy_table =
         LazyTable::new(Arc::new(client), namespace_name, table_name).with_table(Arc::new(table));
-    let exec = IndexLakeSearchExec::try_new(lazy_table, table_schema, query, dynamic_fields, None)?;
+    let exec = IndexLakeSearchExec::try_new(
+        lazy_table,
+        table_schema,
+        query,
+        dynamic_fields,
+        None,
+        Some(2),
+    )?;
 
     // Verify exec schema includes dynamic field
     let schema = exec.schema();
@@ -929,7 +936,14 @@ async fn datafusion_search_exec_serialization(
     let client = Arc::new(client);
     let lazy_table = LazyTable::new(client.clone(), namespace_name.clone(), table_name.clone())
         .with_table(Arc::new(table));
-    let exec = IndexLakeSearchExec::try_new(lazy_table, table_schema, query, dynamic_fields, None)?;
+    let exec = IndexLakeSearchExec::try_new(
+        lazy_table,
+        table_schema,
+        query,
+        dynamic_fields,
+        None,
+        Some(1),
+    )?;
     let exec = Arc::new(exec);
 
     // Serialize and deserialize

--- a/integrations/datafusion/src/codec.rs
+++ b/integrations/datafusion/src/codec.rs
@@ -132,6 +132,7 @@ impl PhysicalExtensionCodec for IndexLakePhysicalCodec {
                     query,
                     node.dynamic_fields.clone(),
                     projection,
+                    node.limit.map(|l| l as usize),
                 )?))
             }
             IndexLakePhysicalPlanType::Update(node) => {

--- a/integrations/datafusion/src/search.rs
+++ b/integrations/datafusion/src/search.rs
@@ -34,6 +34,7 @@ impl IndexLakeSearchExec {
         query: Arc<dyn SearchQuery>,
         dynamic_fields: Vec<String>,
         projection: Option<Vec<usize>>,
+        limit: Option<usize>,
     ) -> Result<Self, DataFusionError> {
         let projected_schema = project_schema(&output_schema, projection.as_ref())?;
         let exec_schema =
@@ -50,7 +51,7 @@ impl IndexLakeSearchExec {
             query,
             dynamic_fields,
             projection,
-            limit: None,
+            limit,
             properties,
         })
     }
@@ -124,10 +125,21 @@ impl ExecutionPlan for IndexLakeSearchExec {
         self.limit
     }
 
-    fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
-        // Create a new search query with the requested limit
-        // Note: we can't modify the query in place, so we return None
-        None
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        match IndexLakeSearchExec::try_new(
+            self.lazy_table.clone(),
+            self.output_schema.clone(),
+            self.query.clone(),
+            self.dynamic_fields.clone(),
+            self.projection.clone(),
+            limit,
+        ) {
+            Ok(exec) => Some(Arc::new(exec)),
+            Err(e) => {
+                log::error!("[indexlake] Failed to create IndexLakeSearchExec with fetch: {e}");
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Add `limit` parameter to `IndexLakeSearchExec::try_new()` and implement `with_fetch()` properly.

## Changes

### `IndexLakeSearchExec::try_new`
- Add `limit: Option\<usize\>` parameter (6th param)
- Use it instead of default `None`

### `IndexLakeSearchExec::with_fetch`
- Now creates a new `IndexLakeSearchExec` with the requested fetch limit
- Matches the same pattern as `IndexLakeScanExec::with_fetch`

### `codec.rs`
- Decoder passes `node.limit` (already present in proto) to `try_new`

### Test updates
- 2 test sites updated to pass `Some(2)` / `Some(1)` as limit

## Verification
- ✅ Build
- ✅ fmt
- ✅ clippy
- ✅ `datafusion_search_exec::case_1` test pass