### PR TITLE
fix(rabitq): support FixedSizeList in addition to List

### DIFF
--- a/indexes/rabitq/src/kind.rs
+++ b/indexes/rabitq/src/kind.rs
@@ -62,7 +62,7 @@ impl IndexKind for RabitqIndexKind {
             .arrow_schema
             .field_with_name(key_column_name)?;
         match key_field.data_type() {
-            DataType::List(inner) => {
+            DataType::List(inner) | DataType::FixedSizeList(inner, _) => {
                 if !matches!(inner.data_type(), DataType::Float32) || inner.is_nullable() {
                     return Err(ILError::index(
                         "RaBitQ index key column must be a list of non-nullable float32",


### PR DESCRIPTION
## Summary

Extend rabitq index type validation to accept FixedSizeList in addition to List for vector columns.

## Root Cause

VECTOR(n) SQL type maps to Arrow's `FixedSizeList(Float32, n)`, but the rabitq index only accepted `DataType::List`. This caused CREATE INDEX to fail with 'RaBitQ index key column must be a list of non-nullable float32'.

## Change

- `indexes/rabitq/src/kind.rs`: add `FixedSizeList(inner, _)` as a valid key column type alongside `List(inner)`

## Related

- data-fabric 221 env rabitq index creation failure