### PR TITLE
fix: add Float32 support for FixedSizeList value builder

### DIFF
--- a/indexlake/src/catalog/row.rs
+++ b/indexlake/src/catalog/row.rs
@@ -985,6 +985,16 @@ pub fn rows_to_record_batch(schema: &SchemaRef, rows: &[Row]) -> ILResult<Record
                                 *len
                             );
                         }
+                        DataType::Float32 => {
+                            fixed_size_list_values_builder_append!(
+                                v,
+                                builder,
+                                Float32Builder,
+                                inner_field,
+                                Float32Array,
+                                *len
+                            );
+                        }
                         _ => {
                             return Err(ILError::not_supported(format!(
                                 "Not supported data type: {}",

--- a/integration-tests/tests/table_ops.rs
+++ b/integration-tests/tests/table_ops.rs
@@ -208,6 +208,11 @@ async fn table_data_types(
             true,
         ),
         Field::new(
+            "fixed_size_list_float32_col",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, false)), 4),
+            true,
+        ),
+        Field::new(
             "large_list_int32_col",
             DataType::LargeList(Arc::new(Field::new("item", DataType::Int32, true))),
             true,
@@ -358,6 +363,17 @@ async fn table_data_types(
                 .into_iter(),
                 2,
             )),
+            Arc::new(
+                FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                    vec![
+                        Some(vec![Some(1.0f32), Some(2.0f32), Some(3.0f32), Some(4.0f32)]),
+                        Some(vec![Some(5.0f32), Some(6.0f32), Some(7.0f32), Some(8.0f32)]),
+                        None,
+                    ]
+                    .into_iter(),
+                    4,
+                ),
+            ),
             Arc::new(LargeListArray::from_iter_primitive::<Int32Type, _, _>(
                 vec![
                     Some(vec![Some(0i32), Some(1i32)]),


### PR DESCRIPTION
## Summary

Add missing Float32 match arm in the FixedSizeList values builder in `catalog/row.rs`.

## Root Cause

VECTOR(n) SQL type maps to FixedSizeList(Float32, n). The row builder had Float16 and Float64 support but was missing Float32, causing `Not supported data type: Float32` error when inserting data with VECTOR columns.

## Change

`indexlake/src/catalog/row.rs`: add DataType::Float32 arm to FixedSizeList values builder match.

## Related

- data-fabric 221 env rabitq index creation flow