### PR TITLE
fix(rabitq): support FixedSizeList key columns in index builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2876,6 +2876,7 @@ dependencies = [
  "indexlake-index-bm25",
  "indexlake-index-btree",
  "indexlake-index-hnsw",
+ "indexlake-index-rabitq",
  "indexlake-index-rstar",
  "indexlake-storage-fs",
  "indexlake-storage-s3",

--- a/indexes/rabitq/src/builder.rs
+++ b/indexes/rabitq/src/builder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::array::{Array, FixedSizeBinaryArray, Float32Array, ListArray};
+use arrow::array::{Array, ArrayRef, FixedSizeBinaryArray, FixedSizeListArray, Float32Array, ListArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -16,7 +16,7 @@ use crate::{RabitqIndex, RabitqIndexParams, RabitqMetric};
 pub struct RabitqIndexBuilder {
     index_def: IndexDefinitionRef,
     params: RabitqIndexParams,
-    row_id_vector: Vec<(FixedSizeBinaryArray, ListArray)>,
+    row_id_vector: Vec<(FixedSizeBinaryArray, ArrayRef)>,
     loaded: Option<RabitqIndex>,
 }
 
@@ -46,14 +46,11 @@ impl RabitqIndexBuilder {
         let mut row_ids: Vec<Uuid> = Vec::new();
         let mut vectors: Vec<Vec<f32>> = Vec::new();
         for (row_id_array, key_column) in &self.row_id_vector {
-            for (row_id_bytes, vector_arr) in row_id_array.iter().zip(key_column.iter()) {
+            let vector_options = extract_vectors(key_column)?;
+            for (row_id_bytes, vector_opt) in row_id_array.iter().zip(vector_options.iter()) {
                 let row_id = Uuid::from_slice(row_id_bytes.expect("row id is null"))?;
-                if let Some(arr) = vector_arr {
-                    let float_arr = arr
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| ILError::index("Vector is not a float32 array"))?;
-                    vectors.push(float_arr.values().to_vec());
+                if let Some(vector) = vector_opt {
+                    vectors.push(vector.clone());
                     row_ids.push(row_id);
                 }
             }
@@ -70,6 +67,50 @@ impl RabitqIndexBuilder {
             row_ids,
             metric: self.params.metric.clone(),
         })
+    }
+}
+
+fn extract_vectors(key_column: &ArrayRef) -> ILResult<Vec<Option<Vec<f32>>>> {
+    match key_column.data_type() {
+        DataType::List(_) => {
+            let list = key_column
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .ok_or_else(|| ILError::index("Key column is not a list array"))?;
+            Ok(list
+                .iter()
+                .map(|opt| {
+                    opt.map(|arr| {
+                        arr.as_any()
+                            .downcast_ref::<Float32Array>()
+                            .expect("Vector is not a float32 array")
+                            .values()
+                            .to_vec()
+                    })
+                })
+                .collect())
+        }
+        DataType::FixedSizeList(_, _) => {
+            let fixed_size_list = key_column
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .ok_or_else(|| ILError::index("Key column is not a fixed size list array"))?;
+            Ok(fixed_size_list
+                .iter()
+                .map(|opt| {
+                    opt.map(|arr| {
+                        arr.as_any()
+                            .downcast_ref::<Float32Array>()
+                            .expect("Vector is not a float32 array")
+                            .values()
+                            .to_vec()
+                    })
+                })
+                .collect())
+        }
+        _ => Err(ILError::index(
+            "Key column must be a list or fixed size list of float32",
+        )),
     }
 }
 
@@ -131,12 +172,22 @@ impl IndexBuilder for RabitqIndexBuilder {
         let row_id_array = extract_row_id_array_from_record_batch(batch)?;
         let key_column_name = &self.index_def.key_columns[0];
         let key_column_index = batch.schema_ref().index_of(key_column_name)?;
-        let key_column = batch
-            .column(key_column_index)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .ok_or_else(|| ILError::index("Key column is not a list array"))?;
-        self.row_id_vector.push((row_id_array, key_column.clone()));
+        let key_column = batch.column(key_column_index).clone();
+        match key_column.data_type() {
+            DataType::List(inner) | DataType::FixedSizeList(inner, _) => {
+                if !matches!(inner.data_type(), DataType::Float32) || inner.is_nullable() {
+                    return Err(ILError::index(
+                        "RaBitQ index key column must be a list of non-nullable float32",
+                    ));
+                }
+            }
+            _ => {
+                return Err(ILError::index(
+                    "RaBitQ index key column must be a list of non-nullable float32",
+                ));
+            }
+        }
+        self.row_id_vector.push((row_id_array, key_column));
         Ok(())
     }
 
@@ -165,13 +216,9 @@ impl IndexBuilder for RabitqIndexBuilder {
                 .as_any()
                 .downcast_ref::<FixedSizeBinaryArray>()
                 .ok_or_else(|| ILError::index("Row ID array is not a FixedSizeBinaryArray"))?;
-            let key_column = batch
-                .column(1)
-                .as_any()
-                .downcast_ref::<ListArray>()
-                .ok_or_else(|| ILError::index("Key column is not a list array"))?;
+            let key_column = batch.column(1).clone();
             self.row_id_vector
-                .push((row_id_array.clone(), key_column.clone()));
+                .push((row_id_array.clone(), key_column));
         }
         Ok(())
     }
@@ -182,7 +229,7 @@ impl IndexBuilder for RabitqIndexBuilder {
         for (row_id_array, key_column) in &self.row_id_vector {
             let batch = RecordBatch::try_new(
                 schema.clone(),
-                vec![Arc::new(row_id_array.clone()), Arc::new(key_column.clone())],
+                vec![Arc::new(row_id_array.clone()), key_column.clone()],
             )?;
             stream_writer.write(&batch)?;
         }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -35,6 +35,7 @@ indexlake-datafusion = { workspace = true }
 indexlake-index-bm25 = { workspace = true }
 indexlake-index-btree = { workspace = true }
 indexlake-index-hnsw = { workspace = true }
+indexlake-index-rabitq = { workspace = true }
 indexlake-index-rstar = { workspace = true }
 rstest = { workspace = true }
 

--- a/integration-tests/src/data.rs
+++ b/integration-tests/src/data.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    BinaryArray, Float32Builder, Int32Array, ListBuilder, RecordBatch, StringArray,
+    BinaryArray, FixedSizeListBuilder, Float32Builder, Int32Array, ListBuilder, RecordBatch,
+    StringArray,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use geo::{Geometry, Point};
@@ -299,6 +300,74 @@ pub async fn prepare_btree_string_table(
         .insert(TableInsertion::new(vec![record_batch]))
         .await?;
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    Ok(table)
+}
+
+pub async fn prepare_simple_fixed_size_vector_table(
+    client: &Client,
+    format: DataFileFormat,
+) -> ILResult<Table> {
+    let namespace_name = uuid::Uuid::new_v4().to_string();
+    client.create_namespace(&namespace_name, true).await?;
+
+    let fixed_size_list_inner_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(fixed_size_list_inner_field.clone(), 3),
+            true,
+        ),
+    ]));
+    let table_config = TableConfig {
+        inline_row_count_limit: 3,
+        parquet_row_group_size: 2,
+        preferred_data_file_format: format,
+    };
+    let table_name = uuid::Uuid::new_v4().to_string();
+    let table_creation = TableCreation {
+        namespace_name: namespace_name.clone(),
+        table_name: table_name.clone(),
+        schema: table_schema.clone(),
+        config: table_config,
+        ..Default::default()
+    };
+    client.create_table(table_creation).await?;
+
+    let table = client.load_table(&namespace_name, &table_name).await?;
+
+    let mut fixed_size_list_builder = FixedSizeListBuilder::new(
+        Float32Builder::new(),
+        3,
+    )
+    .with_field(fixed_size_list_inner_field.clone());
+    fixed_size_list_builder.values().append_slice(&[10.0, 10.0, 10.0]);
+    fixed_size_list_builder.append(true);
+    fixed_size_list_builder.values().append_slice(&[20.0, 20.0, 20.0]);
+    fixed_size_list_builder.append(true);
+    fixed_size_list_builder.values().append_slice(&[30.0, 30.0, 30.0]);
+    fixed_size_list_builder.append(true);
+    fixed_size_list_builder.values().append_slice(&[40.0, 40.0, 40.0]);
+    fixed_size_list_builder.append(true);
+    let fixed_size_list_array = fixed_size_list_builder.finish();
+
+    let record_batch = RecordBatch::try_new(
+        table_schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(fixed_size_list_array),
+        ],
+    )?;
+    table
+        .insert(TableInsertion::new(vec![record_batch]))
+        .await?;
+
+    // wait for dump task to finish
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    assert_inline_row_count(&table, |count| count > 0).await?;
+    assert_data_file_count(&table, |count| count > 0).await?;
 
     Ok(table)
 }

--- a/integration-tests/tests/index_rabitq.rs
+++ b/integration-tests/tests/index_rabitq.rs
@@ -1,0 +1,71 @@
+use indexlake::Client;
+use indexlake::catalog::Catalog;
+use indexlake::index::IndexKind;
+use indexlake::storage::{DataFileFormat, Storage};
+use indexlake::table::TableSearch;
+use indexlake_integration_tests::data::prepare_simple_fixed_size_vector_table;
+use indexlake_integration_tests::{
+    catalog_postgres, catalog_sqlite, init_env_logger, storage_fs, storage_s3,
+};
+use std::sync::Arc;
+
+use indexlake::table::IndexCreation;
+use indexlake_index_rabitq::{RabitqIndexKind, RabitqIndexParams, RabitqMetric, RabitqSearchQuery};
+use indexlake_integration_tests::utils::table_search;
+
+#[rstest::rstest]
+#[case(async { catalog_sqlite() }, async { storage_fs() }, DataFileFormat::ParquetV2)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV1)]
+#[case(async { catalog_postgres().await }, async { storage_s3().await }, DataFileFormat::ParquetV2)]
+#[tokio::test(flavor = "multi_thread")]
+async fn create_rabitq_index(
+    #[future(awt)]
+    #[case]
+    catalog: Arc<dyn Catalog>,
+    #[future(awt)]
+    #[case]
+    storage: Arc<dyn Storage>,
+    #[case] format: DataFileFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    init_env_logger();
+
+    let mut client = Client::new(catalog, storage);
+    client.register_index_kind(Arc::new(RabitqIndexKind));
+
+    let table = prepare_simple_fixed_size_vector_table(&client, format).await?;
+    let namespace_name = table.namespace_name.clone();
+    let table_name = table.table_name.clone();
+
+    let index_creation = IndexCreation {
+        name: "rabitq_index".to_string(),
+        kind: RabitqIndexKind.kind().to_string(),
+        key_columns: vec!["vector".to_string()],
+        params: Arc::new(RabitqIndexParams {
+            metric: RabitqMetric::L2,
+            total_bits: 7,
+        }),
+        concurrency: 1,
+        if_not_exists: false,
+    };
+    table.create_index(index_creation.clone()).await?;
+
+    let search = TableSearch {
+        query: Arc::new(RabitqSearchQuery {
+            vector: vec![26.0, 26.0, 26.0],
+        }),
+        projection: None,
+        dynamic_fields: vec!["score".to_string()],
+        limit: Some(2),
+        concurrency: 8,
+    };
+
+    let table = client.load_table(&namespace_name, &table_name).await?;
+    let table_str = table_search(&table, search).await?;
+    println!("{}", table_str);
+    assert!(
+        table_str.contains("30.0, 30.0, 30.0") || table_str.contains("20.0, 20.0, 20.0"),
+        "expected search result to contain nearby vectors, got:\n{table_str}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The rabitq index kind already accepts FixedSizeList(Float32) columns after #193, but the index builder still downcasts the key column to ListArray, causing index creation on VECTOR columns to fail with "Key column is not a list array". This PR makes the builder handle both List and FixedSizeList arrays, and adds an integration test for rabitq on FixedSizeList vectors.