### PR TITLE
fix(hnsw): ef_search in query, explicit beam width via nearest()

### DIFF
--- a/benchmarks/src/bin/indexlake_hnsw.rs
+++ b/benchmarks/src/bin/indexlake_hnsw.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         key_columns: vec!["vector".to_string()],
         params: Arc::new(HnswIndexParams {
             ef_construction: 400,
-            ef_search: 100,
         }),
         concurrency: 1,
         if_not_exists: false,
@@ -104,6 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let table_search = TableSearch {
         query: Arc::new(HnswSearchQuery {
             vector: vec![500.0; 1024],
+            ef_search: 100,
         }),
         projection: None,
         dynamic_fields: vec![],

--- a/indexes/hnsw/src/builder.rs
+++ b/indexes/hnsw/src/builder.rs
@@ -211,7 +211,6 @@ impl IndexBuilder for HnswIndexBuilder {
         Ok(Box::new(HnswIndex::new(
             std::mem::take(&mut self.hnsw),
             std::mem::take(&mut self.row_ids),
-            self.params.ef_search,
         )))
     }
 }

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -14,9 +14,15 @@ use uuid::Uuid;
 
 use crate::Euclidean;
 
+fn default_ef_search() -> usize {
+    100
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HnswSearchQuery {
     pub vector: Vec<f32>,
+    #[serde(default = "default_ef_search")]
+    pub ef_search: usize,
 }
 
 impl SearchQuery for HnswSearchQuery {
@@ -50,20 +56,11 @@ impl indexlake::index::SearchQueryCodec for HnswSearchQueryCodec {
 pub struct HnswIndex {
     hnsw: Hnsw<Euclidean, Vec<f32>, Pcg64, 24, 48>,
     row_ids: Vec<Uuid>,
-    ef_search: usize,
 }
 
 impl HnswIndex {
-    pub fn new(
-        hnsw: Hnsw<Euclidean, Vec<f32>, Pcg64, 24, 48>,
-        row_ids: Vec<Uuid>,
-        ef_search: usize,
-    ) -> Self {
-        Self {
-            hnsw,
-            row_ids,
-            ef_search,
-        }
+    pub fn new(hnsw: Hnsw<Euclidean, Vec<f32>, Pcg64, 24, 48>, row_ids: Vec<Uuid>) -> Self {
+        Self { hnsw, row_ids }
     }
 }
 
@@ -97,7 +94,7 @@ impl Index for HnswIndex {
         // from the number of requested results. hnsw::nearest() uses ef to
         // bound the candidate pool, giving better recall than knn() which
         // internally sets ef = num + 16.
-        let ef = self.ef_search.max(limit).min(total);
+        let ef = query.ef_search.max(limit).min(total);
         let mut searcher = Searcher::<u32>::default();
         let mut dest: Vec<Neighbor<u32>> = vec![
             Neighbor {

--- a/indexes/hnsw/src/index.rs
+++ b/indexes/hnsw/src/index.rs
@@ -14,14 +14,9 @@ use uuid::Uuid;
 
 use crate::Euclidean;
 
-fn default_ef_search() -> usize {
-    100
-}
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HnswSearchQuery {
     pub vector: Vec<f32>,
-    #[serde(default = "default_ef_search")]
     pub ef_search: usize,
 }
 

--- a/indexes/hnsw/src/kind.rs
+++ b/indexes/hnsw/src/kind.rs
@@ -86,12 +86,6 @@ impl IndexKind for HnswIndexKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HnswIndexParams {
     pub ef_construction: usize,
-    #[serde(default = "default_ef_search")]
-    pub ef_search: usize,
-}
-
-fn default_ef_search() -> usize {
-    100
 }
 
 impl IndexParams for HnswIndexParams {

--- a/integration-tests/tests/index_hnsw.rs
+++ b/integration-tests/tests/index_hnsw.rs
@@ -44,7 +44,6 @@ async fn create_hnsw_index(
         key_columns: vec!["vector".to_string()],
         params: Arc::new(HnswIndexParams {
             ef_construction: 400,
-            ef_search: 100,
         }),
         concurrency: 1,
         if_not_exists: false,
@@ -54,6 +53,7 @@ async fn create_hnsw_index(
     let mut search = TableSearch {
         query: Arc::new(HnswSearchQuery {
             vector: vec![26.0, 26.0, 26.0],
+            ef_search: 100,
         }),
         projection: None,
         dynamic_fields: vec![],
@@ -120,7 +120,6 @@ async fn create_hnsw_index_fixed_size_list(
         key_columns: vec!["vector".to_string()],
         params: Arc::new(HnswIndexParams {
             ef_construction: 400,
-            ef_search: 100,
         }),
         concurrency: 1,
         if_not_exists: false,
@@ -130,6 +129,7 @@ async fn create_hnsw_index_fixed_size_list(
     let mut search = TableSearch {
         query: Arc::new(HnswSearchQuery {
             vector: vec![26.0, 26.0, 26.0],
+            ef_search: 100,
         }),
         projection: None,
         dynamic_fields: vec![],


### PR DESCRIPTION
## Summary

Two fixes for the HNSW index:

### 1. Recall fix — explicit search beam width

The hnsw crate's `knn()` hardcodes `ef = num + 16`, meaning a top-20 query only explores \~36 candidates. Poor recall because the beam covers only one direction.

**Fix**: Replace `knn()` with `nearest()` using explicit `ef` set to `max(ef_search, limit)`.

### 2. Distance fix — `f32::from_bits()`

`Euclidean::distance()` returns `f32::to_bits()` as `u32` for HNSW internal ordering. The old `as f64` cast produced garbage values like `1088271319.0` instead of the real L2 distance `6.928`.

**Fix**: `f32::from_bits(neighbor.distance) as f64`.

### 3. `ef_search` placed in query not index

`ef_search` is a search-time parameter, not a build-time one. Placed in `HnswSearchQuery` so each query can independently control the recall/speed trade-off. Default 100.

## Changes

| File | Change |
|------|--------|
| `kind.rs` | No change (ef_search removed from params) |
| `index.rs` | Add ef_search to HnswSearchQuery, use nearest() with explicit ef, from_bits fix |
| `builder.rs` | No longer passes ef_search to HnswIndex |
| `index_hnsw.rs` | ef_search in query, not params |
| `indexlake_hnsw.rs` | ef_search in query, not params |