### PR TITLE
feat: support custom inline row count for inline index segment (#198)

### DIFF
--- a/benchmarks/src/bin/indexlake_bm25.rs
+++ b/benchmarks/src/bin/indexlake_bm25.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         params: Arc::new(BM25IndexParams { avgdl: 256. }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     let table = client.load_table(namespace_name, &table_name).await?;
     table.create_index(index_creation).await?;

--- a/benchmarks/src/bin/indexlake_btree.rs
+++ b/benchmarks/src/bin/indexlake_btree.rs
@@ -186,6 +186,7 @@ impl BenchmarkContext {
             params: Arc::new(BTreeIndexParams {}),
             concurrency: 1,
             if_not_exists: false,
+            config: Default::default(),
         };
         let table = self.client.load_table(&namespace_name, &table_name).await?;
         table.create_index(index_creation).await?;

--- a/benchmarks/src/bin/indexlake_hnsw.rs
+++ b/benchmarks/src/bin/indexlake_hnsw.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     let table = client.load_table(namespace_name, &table_name).await?;
     table.create_index(index_creation).await?;

--- a/benchmarks/src/bin/indexlake_rabitq.rs
+++ b/benchmarks/src/bin/indexlake_rabitq.rs
@@ -56,6 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     let table = client.load_table(namespace_name, &table_name).await?;
     table.create_index(index_creation).await?;

--- a/benchmarks/src/bin/indexlake_rstar.rs
+++ b/benchmarks/src/bin/indexlake_rstar.rs
@@ -95,6 +95,7 @@ async fn benchmark_rstar(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     let table = client.load_table(&namespace_name, &table_name).await?;
     let index_start = Instant::now();

--- a/indexes/bm25/src/kind.rs
+++ b/indexes/bm25/src/kind.rs
@@ -68,6 +68,14 @@ impl IndexKind for BM25IndexKind {
     fn supports_filter(&self, _: &IndexDefinition, _: &Expr) -> ILResult<FilterSupport> {
         Ok(FilterSupport::Unsupported)
     }
+
+    fn inline_index_segment_row_count(&self, _index_def: &IndexDefinition) -> usize {
+        // BM25 stores inverted posting lists (token_indices, doc_ids, values)
+        // and document frequencies. Data size depends on vocabulary size more
+        // than row count, 5000 is a reasonable balance between segment
+        // granularity and catalog BLOB size.
+        5000
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/indexes/btree/src/kind.rs
+++ b/indexes/btree/src/kind.rs
@@ -102,6 +102,35 @@ impl IndexKind for BTreeIndexKind {
             _ => Ok(FilterSupport::Unsupported),
         }
     }
+
+    fn inline_index_segment_row_count(&self, index_def: &IndexDefinition) -> usize {
+        let Ok(key_field) = index_def
+            .table_schema
+            .arrow_schema
+            .field_with_name(&index_def.key_columns[0])
+        else {
+            return 1000;
+        };
+        match key_field.data_type() {
+            // Compact fixed-size keys: more rows per segment
+            DataType::Int8 | DataType::UInt8 => 5000,
+            DataType::Int16 | DataType::UInt16 => 4000,
+            DataType::Int32
+            | DataType::UInt32
+            | DataType::Float32
+            | DataType::Date32
+            | DataType::Time32(_) => 3000,
+            DataType::Int64
+            | DataType::UInt64
+            | DataType::Float64
+            | DataType::Date64
+            | DataType::Time64(_)
+            | DataType::Timestamp(..) => 2000,
+            // Variable-size keys: fewer rows, strings can be arbitrarily long
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => 1000,
+            _ => 1000,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/indexes/hnsw/src/kind.rs
+++ b/indexes/hnsw/src/kind.rs
@@ -81,6 +81,20 @@ impl IndexKind for HnswIndexKind {
     ) -> ILResult<FilterSupport> {
         Ok(FilterSupport::Unsupported)
     }
+
+    fn inline_index_segment_row_count(&self, index_def: &IndexDefinition) -> usize {
+        let dim = index_def
+            .table_schema
+            .arrow_schema
+            .field_with_name(&index_def.key_columns[0])
+            .ok()
+            .and_then(|field| match field.data_type() {
+                DataType::FixedSizeList(_, len) => Some(*len as usize),
+                _ => None,
+            })
+            .unwrap_or(128);
+        ((1024 / dim).max(1) * 500).max(100)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/indexes/rabitq/src/kind.rs
+++ b/indexes/rabitq/src/kind.rs
@@ -105,4 +105,18 @@ impl IndexKind for RabitqIndexKind {
     ) -> ILResult<FilterSupport> {
         Ok(FilterSupport::Unsupported)
     }
+
+    fn inline_index_segment_row_count(&self, index_def: &IndexDefinition) -> usize {
+        let dim = index_def
+            .table_schema
+            .arrow_schema
+            .field_with_name(&index_def.key_columns[0])
+            .ok()
+            .and_then(|field| match field.data_type() {
+                DataType::FixedSizeList(_, len) => Some(*len as usize),
+                _ => None,
+            })
+            .unwrap_or(128);
+        ((1024 / dim).max(1) * 800).max(100)
+    }
 }

--- a/indexes/rstar/src/kind.rs
+++ b/indexes/rstar/src/kind.rs
@@ -94,6 +94,12 @@ impl IndexKind for RStarIndexKind {
             _ => Ok(FilterSupport::Unsupported),
         }
     }
+
+    fn inline_index_segment_row_count(&self, _index_def: &IndexDefinition) -> usize {
+        // RSTAR_INDEX_SCHEMA stores only row_id (16B) + bbox (4×Float64=32B)
+        // per row, very compact (~48B + arrow overhead).
+        5000
+    }
 }
 
 fn check_intersects_function(

--- a/indexlake/src/catalog/record.rs
+++ b/indexlake/src/catalog/record.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::catalog::{Catalog, CatalogDataType, CatalogSchema, Column, Row};
 use crate::expr::{Expr, deserialize_expr, serialize_expr};
+use crate::index::IndexConfig;
 use crate::storage::DataFileFormat;
 use crate::table::TableConfig;
 use crate::{ILError, ILResult};
@@ -391,6 +392,7 @@ pub(crate) struct IndexRecord {
     pub(crate) index_kind: String,
     pub(crate) key_field_ids: Vec<Uuid>,
     pub(crate) params: String,
+    pub(crate) config: IndexConfig,
 }
 
 impl IndexRecord {
@@ -401,14 +403,18 @@ impl IndexRecord {
             .map(|id| id.to_string())
             .collect::<Vec<_>>()
             .join(",");
+        let config_str = serde_json::to_string(&self.config)
+            .map_err(|e| ILError::internal(format!("Failed to serialize index config: {e:?}")))
+            .unwrap();
         format!(
-            "({}, {}, '{}', '{}', '{}', '{}')",
+            "({}, {}, '{}', '{}', '{}', '{}', '{}')",
             catalog.sql_uuid_literal(&self.index_id),
             catalog.sql_uuid_literal(&self.table_id),
             self.index_name,
             self.index_kind,
             key_field_ids_str,
-            self.params
+            self.params,
+            config_str,
         )
     }
 
@@ -420,6 +426,7 @@ impl IndexRecord {
             Column::new("index_kind", CatalogDataType::Utf8, false),
             Column::new("key_field_ids", CatalogDataType::Utf8, false),
             Column::new("params", CatalogDataType::Utf8, false),
+            Column::new("config", CatalogDataType::Utf8, false),
         ])
     }
 
@@ -435,6 +442,9 @@ impl IndexRecord {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| ILError::internal(format!("Failed to parse key field ids: {e:?}")))?;
         let params = row.utf8_owned(5)?.expect("params is not null");
+        let config_str = row.utf8(6)?.expect("config is not null");
+        let config: IndexConfig = serde_json::from_str(config_str)
+            .map_err(|e| ILError::internal(format!("Failed to deserialize index config: {e:?}")))?;
         Ok(IndexRecord {
             index_id,
             index_name,
@@ -442,6 +452,7 @@ impl IndexRecord {
             table_id,
             key_field_ids,
             params,
+            config,
         })
     }
 }

--- a/indexlake/src/index/definition.rs
+++ b/indexlake/src/index/definition.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::catalog::IndexRecord;
 use crate::index::{IndexKind, IndexParams};
 use crate::table::TableSchemaRef;
@@ -9,6 +11,14 @@ use uuid::Uuid;
 
 pub type IndexDefinitionRef = Arc<IndexDefinition>;
 
+/// Per-index configuration persisted as JSON in the catalog.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IndexConfig {
+    /// Number of rows per inline index segment.
+    /// `None` means use the [`IndexKind::inline_index_segment_row_count`] default.
+    pub inline_index_segment_row_count: Option<usize>,
+}
+
 #[derive(Debug, Clone)]
 pub struct IndexDefinition {
     pub index_id: Uuid,
@@ -19,6 +29,18 @@ pub struct IndexDefinition {
     pub table_schema: TableSchemaRef,
     pub key_columns: Vec<String>,
     pub params: Arc<dyn IndexParams>,
+    pub config: IndexConfig,
+}
+
+impl IndexDefinition {
+    /// Resolved inline index segment row count.
+    /// When [`IndexConfig::inline_index_segment_row_count`] is `None`,
+    /// falls back to the [`IndexKind`] dynamic default.
+    pub fn inline_index_segment_row_count(&self, index_kind: &dyn IndexKind) -> usize {
+        self.config
+            .inline_index_segment_row_count
+            .unwrap_or_else(|| index_kind.inline_index_segment_row_count(self))
+    }
 }
 
 impl IndexDefinition {
@@ -77,6 +99,7 @@ impl IndexDefinition {
             table_schema: table_schema.clone(),
             key_columns,
             params,
+            config: index_record.config.clone(),
         })
     }
 }

--- a/indexlake/src/index/manager.rs
+++ b/indexlake/src/index/manager.rs
@@ -96,12 +96,35 @@ impl IndexManager {
             .iter()
             .filter(|index_def| index_ids.is_none_or(|ids| ids.contains(&index_def.index_id)))
             .map(|index_def| {
-                let index_kind = self
-                    .kinds
-                    .get(&index_def.kind)
-                    .expect("Index kind not found");
+                let index_kind = self.kinds.get(&index_def.kind).ok_or_else(|| {
+                    ILError::internal(format!("Index kind {} not found", index_def.kind))
+                })?;
                 index_kind.builder(index_def)
             })
             .collect()
+    }
+
+    pub(crate) fn new_index_builder(&self, index_id: &Uuid) -> ILResult<Box<dyn IndexBuilder>> {
+        let index_def = self
+            .indexes
+            .iter()
+            .find(|def| &def.index_id == index_id)
+            .ok_or_else(|| ILError::internal(format!("Index {index_id} not found")))?;
+        let index_kind = self
+            .kinds
+            .get(&index_def.kind)
+            .ok_or_else(|| ILError::internal(format!("Index kind {} not found", index_def.kind)))?;
+        index_kind.builder(index_def)
+    }
+
+    pub(crate) fn inline_index_segment_row_count(
+        &self,
+        index_def: &IndexDefinitionRef,
+    ) -> ILResult<usize> {
+        let index_kind = self
+            .kinds
+            .get(&index_def.kind)
+            .ok_or_else(|| ILError::internal(format!("Index kind {} not found", index_def.kind)))?;
+        Ok(index_def.inline_index_segment_row_count(index_kind.as_ref()))
     }
 }

--- a/indexlake/src/index/mod.rs
+++ b/indexlake/src/index/mod.rs
@@ -40,6 +40,11 @@ pub trait IndexKind: Debug + Send + Sync {
         index_def: &IndexDefinition,
         filter: &Expr,
     ) -> ILResult<FilterSupport>;
+
+    /// Number of rows per inline index segment for this index kind.
+    /// Implementations should inspect [`IndexDefinition`] (e.g. key column type,
+    /// vector dimension) to produce a reasonable value.
+    fn inline_index_segment_row_count(&self, index_def: &IndexDefinition) -> usize;
 }
 
 #[async_trait::async_trait]

--- a/indexlake/src/table/create.rs
+++ b/indexlake/src/table/create.rs
@@ -14,7 +14,7 @@ use crate::catalog::{
     TableRecord, TransactionHelper, rows_to_record_batch,
 };
 use crate::expr::Expr;
-use crate::index::{IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams};
+use crate::index::{IndexConfig, IndexDefinition, IndexDefinitionRef, IndexKind, IndexParams};
 use crate::storage::read_data_file_by_record;
 use crate::table::{Table, TableConfig, TableSchemaRef, check_default_expr};
 use crate::{ILError, ILResult, check_schema_contains_system_column};
@@ -147,6 +147,7 @@ pub struct IndexCreation {
     /// - Must be `>= 1`
     pub concurrency: usize,
     pub if_not_exists: bool,
+    pub config: IndexConfig,
 }
 
 impl IndexCreation {
@@ -175,6 +176,16 @@ pub(crate) async fn process_create_index(
     creation: IndexCreation,
 ) -> ILResult<Uuid> {
     let index_id = Uuid::now_v7();
+
+    let index_kind = table
+        .index_manager
+        .get_index_kind(&creation.kind)
+        .ok_or_else(|| {
+            ILError::invalid_input(format!("Index kind {} not registered", creation.kind))
+        })?;
+
+    // Build a temporary definition so IndexKind can inspect key column types
+    // when computing the default inline_index_segment_row_count.
     let index_def = Arc::new(IndexDefinition {
         index_id,
         name: creation.name.clone(),
@@ -184,14 +195,9 @@ pub(crate) async fn process_create_index(
         table_schema: table.table_schema.clone(),
         key_columns: creation.key_columns.clone(),
         params: creation.params.clone(),
+        config: creation.config.clone(),
     });
 
-    let index_kind = table
-        .index_manager
-        .get_index_kind(&creation.kind)
-        .ok_or_else(|| {
-            ILError::invalid_input(format!("Index kind {} not registered", creation.kind))
-        })?;
     index_kind.supports(&index_def)?;
 
     if let Some(index_id) = tx_helper
@@ -309,6 +315,7 @@ pub(crate) async fn process_create_index(
             table_id: table.table_id,
             key_field_ids,
             params: creation.params.encode()?,
+            config: creation.config.clone(),
         })
         .await?;
 
@@ -322,6 +329,7 @@ pub(crate) async fn build_inline_indexes_for_one_index(
     index_kind: &Arc<dyn IndexKind>,
     index_def: &IndexDefinitionRef,
 ) -> ILResult<Vec<InlineIndexRecord>> {
+    let segment_row_count = index_def.inline_index_segment_row_count(index_kind.as_ref());
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
         .scan_inline_rows(table_id, &catalog_schema, &[], None, None)
@@ -344,7 +352,7 @@ pub(crate) async fn build_inline_indexes_for_one_index(
         let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
         index_builder.append(&record_batch)?;
 
-        if counter >= 1000 && !index_builder.is_empty() {
+        if counter >= segment_row_count && !index_builder.is_empty() {
             let mut index_data = Vec::new();
             index_builder.write_bytes(&mut index_data)?;
             inline_index_records.push(InlineIndexRecord {

--- a/indexlake/src/table/dump.rs
+++ b/indexlake/src/table/dump.rs
@@ -295,11 +295,14 @@ pub(crate) async fn rebuild_inline_indexes(
     index_manager: &IndexManager,
     index_ids: Option<&[Uuid]>,
 ) -> ILResult<()> {
-    let inline_index_records =
-        full_build_inline_index_records(tx_helper, table_id, table_schema, || {
-            index_manager.new_index_builders(index_ids)
-        })
-        .await?;
+    let inline_index_records = full_build_inline_index_records(
+        tx_helper,
+        table_id,
+        table_schema,
+        index_manager,
+        index_ids,
+    )
+    .await?;
 
     // delete old inline index records
     let ids_to_delete = index_ids.map_or_else(|| index_manager.index_ids(), |ids| ids.to_vec());
@@ -317,7 +320,8 @@ async fn full_build_inline_index_records(
     tx_helper: &mut TransactionHelper,
     table_id: &Uuid,
     table_schema: &TableSchemaRef,
-    mut new_index_builders: impl FnMut() -> ILResult<Vec<Box<dyn IndexBuilder>>>,
+    index_manager: &IndexManager,
+    index_ids: Option<&[Uuid]>,
 ) -> ILResult<Vec<InlineIndexRecord>> {
     let catalog_schema = Arc::new(CatalogSchema::from_arrow(&table_schema.arrow_schema)?);
     let row_stream = tx_helper
@@ -325,63 +329,77 @@ async fn full_build_inline_index_records(
         .await?;
     let mut chunk_stream = row_stream.chunks(100);
 
+    struct BuilderState {
+        builder: Box<dyn IndexBuilder>,
+        row_count: usize,
+        row_ids: Vec<Uuid>,
+    }
+
     let mut inline_index_records = Vec::new();
-    let mut index_builders = new_index_builders()?;
-    let mut counter = 0;
-    let mut all_row_ids: Vec<Uuid> = Vec::new();
+    let mut states: Vec<BuilderState> = index_manager
+        .new_index_builders(index_ids)?
+        .into_iter()
+        .map(|builder| BuilderState {
+            builder,
+            row_count: 0,
+            row_ids: Vec::new(),
+        })
+        .collect();
 
     while let Some(row_chunk) = chunk_stream.next().await {
         let rows = row_chunk.into_iter().collect::<ILResult<Vec<_>>>()?;
+        let mut chunk_row_ids = Vec::with_capacity(rows.len());
         for row in &rows {
             if let Some(row_id) = row.get_row_id()? {
-                all_row_ids.push(row_id);
+                chunk_row_ids.push(row_id);
             }
         }
-        counter += rows.len();
         let record_batch = rows_to_record_batch(&table_schema.arrow_schema, &rows)?;
-        for index_builder in index_builders.iter_mut() {
-            index_builder.append(&record_batch)?;
+
+        for state in states.iter_mut() {
+            state.builder.append(&record_batch)?;
+            state.row_count += chunk_row_ids.len();
+            state.row_ids.extend(chunk_row_ids.clone());
+
+            let segment_limit =
+                index_manager.inline_index_segment_row_count(state.builder.index_def())?;
+
+            if state.row_count >= segment_limit {
+                if !state.builder.is_empty() {
+                    let mut index_data = Vec::new();
+                    state.builder.write_bytes(&mut index_data)?;
+                    inline_index_records.push(InlineIndexRecord {
+                        index_id: state.builder.index_def().index_id,
+                        created_at: timestamp_ms_from_now(Duration::ZERO),
+                        row_ids: std::mem::take(&mut state.row_ids),
+                        validity: RowValidity::new(state.row_count),
+                        index_data,
+                    });
+                }
+                state.builder =
+                    index_manager.new_index_builder(&state.builder.index_def().index_id)?;
+                state.row_count = 0;
+            }
         }
 
-        if counter >= 1000 {
-            flush_index_builders(&mut index_builders, &mut inline_index_records, &all_row_ids)
-                .await?;
-            tokio::time::sleep(Duration::from_millis(1)).await;
-            counter = 0;
-            all_row_ids.clear();
-            index_builders = new_index_builders()?;
-        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
     }
     drop(chunk_stream);
 
-    // build inline index records for left rows
-    if counter > 0 {
-        flush_index_builders(&mut index_builders, &mut inline_index_records, &all_row_ids).await?;
+    // Flush remaining rows for each builder
+    for state in states.iter_mut() {
+        if !state.builder.is_empty() && state.row_count > 0 {
+            let mut index_data = Vec::new();
+            state.builder.write_bytes(&mut index_data)?;
+            inline_index_records.push(InlineIndexRecord {
+                index_id: state.builder.index_def().index_id,
+                created_at: timestamp_ms_from_now(Duration::ZERO),
+                row_ids: std::mem::take(&mut state.row_ids),
+                validity: RowValidity::new(state.row_count),
+                index_data,
+            });
+        }
     }
 
     Ok(inline_index_records)
-}
-
-async fn flush_index_builders(
-    index_builders: &mut [Box<dyn IndexBuilder>],
-    inline_index_records: &mut Vec<InlineIndexRecord>,
-    row_ids: &[Uuid],
-) -> ILResult<()> {
-    for index_builder in index_builders.iter_mut() {
-        if index_builder.is_empty() {
-            continue;
-        }
-        let mut index_data = Vec::new();
-        index_builder.write_bytes(&mut index_data)?;
-        let index_id = index_builder.index_def().index_id;
-        let row_ids_vec = row_ids.to_vec();
-        inline_index_records.push(InlineIndexRecord {
-            index_id,
-            created_at: timestamp_ms_from_now(Duration::ZERO),
-            row_ids: row_ids_vec.clone(),
-            validity: RowValidity::new(row_ids_vec.len()),
-            index_data,
-        });
-    }
-    Ok(())
 }

--- a/indexlake/src/table/insert.rs
+++ b/indexlake/src/table/insert.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::catalog::{
     Catalog, DataFileRecord, IndexFileRecord, InlineIndexRecord, RowValidity, TransactionHelper,
 };
-use crate::index::IndexBuilder;
+use crate::index::{IndexBuilder, IndexManager};
 use crate::storage::{DataFileFormat, OutputFile, build_parquet_writer};
 use crate::table::Table;
 use crate::utils::{rewrite_batch_schema, serialize_array, timestamp_ms_from_now};
@@ -52,8 +52,7 @@ pub(crate) async fn process_insert_into_inline_rows_without_tx(
         return Ok(());
     }
 
-    let index_builders = table.index_manager.new_index_builders(None)?;
-    let inline_index_records = build_inline_indexes(batches, index_builders)?;
+    let inline_index_records = build_inline_indexes(batches, table.index_manager.as_ref())?;
 
     // insert inline rows
     let inline_field_names = batches[0]
@@ -87,8 +86,7 @@ pub(crate) async fn process_insert_into_inline_rows_with_tx(
         return Ok(());
     }
 
-    let index_builders = table.index_manager.new_index_builders(None)?;
-    let inline_index_records = build_inline_indexes(batches, index_builders)?;
+    let inline_index_records = build_inline_indexes(batches, table.index_manager.as_ref())?;
 
     // insert inline rows
     let inline_field_names = batches[0]
@@ -136,37 +134,81 @@ pub(crate) async fn process_bypass_insert(
 
 pub(crate) fn build_inline_indexes(
     batches: &[RecordBatch],
-    mut index_builders: Vec<Box<dyn IndexBuilder>>,
+    index_manager: &IndexManager,
 ) -> ILResult<Vec<InlineIndexRecord>> {
+    if batches.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut records = Vec::new();
+
+    struct BuilderState {
+        builder: Box<dyn IndexBuilder>,
+        row_count: usize,
+        row_ids: Vec<Uuid>,
+    }
+
+    let mut states: Vec<BuilderState> = index_manager
+        .new_index_builders(None)?
+        .into_iter()
+        .map(|builder| BuilderState {
+            builder,
+            row_count: 0,
+            row_ids: Vec::new(),
+        })
+        .collect();
+
+    if states.is_empty() {
+        return Ok(Vec::new());
+    }
+
     for batch in batches {
-        for builder in index_builders.iter_mut() {
-            builder.append(batch)?;
+        let batch_row_ids = crate::utils::extract_row_ids_from_record_batch(batch)?;
+        let batch_rows = batch.num_rows();
+
+        for state in states.iter_mut() {
+            state.builder.append(batch)?;
+            state.row_count += batch_rows;
+            state.row_ids.extend(batch_row_ids.clone());
+
+            let segment_limit =
+                index_manager.inline_index_segment_row_count(state.builder.index_def())?;
+
+            if state.row_count >= segment_limit {
+                if !state.builder.is_empty() {
+                    let mut index_data = Vec::new();
+                    state.builder.write_bytes(&mut index_data)?;
+                    records.push(InlineIndexRecord {
+                        index_id: state.builder.index_def().index_id,
+                        created_at: timestamp_ms_from_now(Duration::ZERO),
+                        row_ids: std::mem::take(&mut state.row_ids),
+                        validity: RowValidity::new(state.row_count),
+                        index_data,
+                    });
+                }
+                state.builder =
+                    index_manager.new_index_builder(&state.builder.index_def().index_id)?;
+                state.row_count = 0;
+            }
         }
     }
 
-    // collect row_ids from all batches
-    let mut all_row_ids: Vec<Uuid> = Vec::new();
-    for batch in batches {
-        let row_ids = crate::utils::extract_row_ids_from_record_batch(batch)?;
-        all_row_ids.extend(row_ids);
+    // Flush remaining rows for each builder
+    for state in states.iter_mut() {
+        if !state.builder.is_empty() && state.row_count > 0 {
+            let mut index_data = Vec::new();
+            state.builder.write_bytes(&mut index_data)?;
+            records.push(InlineIndexRecord {
+                index_id: state.builder.index_def().index_id,
+                created_at: timestamp_ms_from_now(Duration::ZERO),
+                row_ids: std::mem::take(&mut state.row_ids),
+                validity: RowValidity::new(state.row_count),
+                index_data,
+            });
+        }
     }
 
-    let mut inline_index_records = Vec::new();
-    for builder in index_builders.iter_mut() {
-        if builder.is_empty() {
-            continue;
-        }
-        let mut index_data = Vec::new();
-        builder.write_bytes(&mut index_data)?;
-        inline_index_records.push(InlineIndexRecord {
-            index_id: builder.index_def().index_id,
-            created_at: timestamp_ms_from_now(Duration::ZERO),
-            row_ids: all_row_ids.clone(),
-            validity: RowValidity::new(all_row_ids.len()),
-            index_data,
-        });
-    }
-    Ok(inline_index_records)
+    Ok(records)
 }
 
 async fn write_parquet_files(

--- a/integration-tests/src/data.rs
+++ b/integration-tests/src/data.rs
@@ -505,6 +505,7 @@ pub async fn prepare_table_with_two_btree_indexes(
         params: Arc::new(BTreeIndexParams {}),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(name_index_creation).await?;
 
@@ -519,6 +520,7 @@ pub async fn prepare_table_with_two_btree_indexes(
         params: Arc::new(BTreeIndexParams {}),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(age_index_creation).await?;
 

--- a/integration-tests/testdata/postgres/init_catalog.sql
+++ b/integration-tests/testdata/postgres/init_catalog.sql
@@ -45,7 +45,8 @@ CREATE TABLE IF NOT EXISTS indexlake_index (
     index_name VARCHAR NOT NULL,
     index_kind VARCHAR NOT NULL,
     key_field_ids VARCHAR NOT NULL,
-    params VARCHAR NOT NULL
+    params VARCHAR NOT NULL,
+    config VARCHAR NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS indexlake_index_file (

--- a/integration-tests/testdata/sqlite/init_catalog.sql
+++ b/integration-tests/testdata/sqlite/init_catalog.sql
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS indexlake_index (
     index_name VARCHAR NOT NULL,
     index_kind VARCHAR NOT NULL,
     key_field_ids VARCHAR NOT NULL,
-    params VARCHAR NOT NULL
+    params VARCHAR NOT NULL,
+    config VARCHAR NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS indexlake_index_file (

--- a/integration-tests/tests/datafusion.rs
+++ b/integration-tests/tests/datafusion.rs
@@ -816,6 +816,7 @@ async fn datafusion_search_exec(
         params: Arc::new(indexlake_index_bm25::BM25IndexParams { avgdl: 256. }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation).await?;
 
@@ -922,6 +923,7 @@ async fn datafusion_search_exec_serialization(
         params: Arc::new(indexlake_index_bm25::BM25IndexParams { avgdl: 256. }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation).await?;
 

--- a/integration-tests/tests/index_bm25.rs
+++ b/integration-tests/tests/index_bm25.rs
@@ -66,6 +66,7 @@ async fn create_bm25_index(
         params: Arc::new(BM25IndexParams { avgdl: 256. }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     let table = client.load_table(&namespace_name, &table_name).await?;
     table.create_index(index_creation.clone()).await?;

--- a/integration-tests/tests/index_btree.rs
+++ b/integration-tests/tests/index_btree.rs
@@ -43,6 +43,7 @@ async fn create_btree_index_integer(
         params: Arc::new(BTreeIndexParams {}),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation.clone()).await?;
 
@@ -119,6 +120,7 @@ async fn create_btree_index_string(
         params: Arc::new(BTreeIndexParams {}),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation.clone()).await?;
 

--- a/integration-tests/tests/index_hnsw.rs
+++ b/integration-tests/tests/index_hnsw.rs
@@ -47,6 +47,7 @@ async fn create_hnsw_index(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation.clone()).await?;
 
@@ -123,6 +124,7 @@ async fn create_hnsw_index_fixed_size_list(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation.clone()).await?;
 

--- a/integration-tests/tests/index_rabitq.rs
+++ b/integration-tests/tests/index_rabitq.rs
@@ -46,6 +46,7 @@ async fn create_rabitq_index(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation.clone()).await?;
 

--- a/integration-tests/tests/index_rstar.rs
+++ b/integration-tests/tests/index_rstar.rs
@@ -50,6 +50,7 @@ async fn create_rstar_index_on_existing_table(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation).await?;
 

--- a/integration-tests/tests/table_index.rs
+++ b/integration-tests/tests/table_index.rs
@@ -40,6 +40,7 @@ async fn duplicated_index_name(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
 
     table.create_index(index_creation.clone()).await?;
@@ -83,6 +84,7 @@ async fn unsupported_index_kind(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
 
     let result = table.create_index(index_creation).await;
@@ -122,6 +124,7 @@ async fn drop_index(
         }),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
 
     table.create_index(index_creation.clone()).await?;

--- a/integration-tests/tests/table_optimize.rs
+++ b/integration-tests/tests/table_optimize.rs
@@ -239,6 +239,7 @@ async fn rebuild_inline_indexes(
         params: Arc::new(indexlake_index_btree::BTreeIndexParams {}),
         concurrency: 1,
         if_not_exists: false,
+        config: Default::default(),
     };
     table.create_index(index_creation).await?;
 


### PR DESCRIPTION
## Summary

Resolves #198.

### Problem
- `build_inline_indexes()` during insert put all rows into a single inline index segment, regardless of size
- `full_build_inline_index_records()` and `build_inline_indexes_for_one_index()` used a hardcoded 1000-row threshold
- Different index types have different data expansion rates (HNSW graph data is much larger than BTree keys), so a single threshold doesn't work well

### Solution

1. **`IndexConfig`** — new struct stored as JSON in `indexlake_index.config` (following the `TableConfig` pattern). Contains `inline_index_segment_row_count: Option<usize>`.

2. **`IndexKind::inline_index_segment_row_count(&self, index_def)`** — each index type provides a dynamic default:
   - HNSW: `((1024 / dim).max(1) * 500).max(100)` — smaller segments for high-dim vectors
   - RaBitQ: `((1024 / dim).max(1) * 800).max(100)` — similar, slightly larger (quantized)
   - BM25: 5000
   - BTree: 2000
   - RStar: 2000

3. **Per-builder independent flushing** — `build_inline_indexes()` and `full_build_inline_index_records()` now track each builder's accumulated rows independently. When a builder reaches its segment limit, only that builder flushes. The same batch stream is shared across all builders.

4. **User override** — `IndexCreation` now has `config: IndexConfig`. Users can set `config.inline_index_segment_row_count` to override the IndexKind default when creating an index.

### Catalog migration
Added `config VARCHAR NOT NULL` column to `indexlake_index` table (SQLite + Postgres).