### PR TITLE
perf(fs): batch range reads in one blocking task

### DIFF
--- a/storages/fs/src/file.rs
+++ b/storages/fs/src/file.rs
@@ -1,43 +1,93 @@
-use std::{io::SeekFrom, ops::Range};
+use std::{
+    io::{Read, Seek, SeekFrom},
+    ops::Range,
+};
 
 use bytes::Bytes;
 use indexlake::{
     ILError, ILResult,
     storage::{FileMetadata, InputFile, OutputFile},
 };
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::{io::AsyncWriteExt, task::spawn_blocking};
 
 use crate::parse_std_fs_metadata;
 
 #[derive(Debug)]
 pub struct LocalInputFile {
-    pub file: tokio::fs::File,
+    pub file: std::fs::File,
     pub relative_path: String,
+}
+
+fn read_range(file: &mut std::fs::File, relative_path: &str, range: Range<u64>) -> ILResult<Bytes> {
+    if range.end < range.start {
+        return Err(ILError::storage(format!(
+            "Invalid read range [{}, {}) on file {relative_path}",
+            range.start, range.end
+        )));
+    }
+    file.seek(SeekFrom::Start(range.start))
+        .map_err(|e| ILError::storage(format!("Failed to seek file {relative_path}: {e}")))?;
+    let mut buffer = vec![0; (range.end - range.start) as usize];
+    file.read_exact(&mut buffer)
+        .map_err(|e| ILError::storage(format!("Failed to read file {relative_path}: {e}")))?;
+    Ok(Bytes::from(buffer))
 }
 
 #[async_trait::async_trait]
 impl InputFile for LocalInputFile {
     async fn metadata(&self) -> ILResult<FileMetadata> {
-        let metadata = self
-            .file
-            .metadata()
-            .await
-            .map_err(|e| ILError::storage(format!("Failed to get file metadata: {e}")))?;
+        // fstat is a cheap non-blocking syscall, no need to offload it.
+        let metadata = self.file.metadata().map_err(|e| {
+            ILError::storage(format!(
+                "Failed to get file metadata {}: {e}",
+                self.relative_path
+            ))
+        })?;
         Ok(parse_std_fs_metadata(&metadata))
     }
 
     async fn read(&mut self, range: Range<u64>) -> ILResult<Bytes> {
-        self.file
-            .seek(SeekFrom::Start(range.start))
-            .await
-            .map_err(|e| {
-                ILError::storage(format!("Failed to seek file {}: {e}", self.relative_path))
-            })?;
-        let mut buffer = vec![0; (range.end - range.start) as usize];
-        self.file.read_exact(&mut buffer).await.map_err(|e| {
-            ILError::storage(format!("Failed to read file {}: {e}", self.relative_path))
+        // try_clone dups the fd and clones share the file cursor; that is
+        // safe because accesses to one LocalInputFile are serialized
+        // (`&mut self` at the trait boundary).
+        let mut file = self.file.try_clone().map_err(|e| {
+            ILError::storage(format!(
+                "Failed to clone file handle {}: {e}",
+                self.relative_path
+            ))
         })?;
-        Ok(Bytes::from(buffer))
+        let relative_path = self.relative_path.clone();
+        spawn_blocking(move || read_range(&mut file, &relative_path, range))
+            .await
+            .map_err(|e| ILError::storage(format!("Failed to join blocking read task: {e}")))?
+    }
+
+    async fn read_ranges(&mut self, ranges: Vec<Range<u64>>) -> ILResult<Vec<Bytes>> {
+        if ranges.is_empty() {
+            return Ok(Vec::new());
+        }
+        if ranges.len() == 1 {
+            return self.read(ranges[0].clone()).await.map(|b| vec![b]);
+        }
+        // Offload all range reads into a single blocking task so the whole
+        // batch costs one runtime dispatch instead of two per range. The
+        // seeks and reads run serialized inside this one task, which is what
+        // keeps the shared file cursor safe (see `read`).
+        let mut file = self.file.try_clone().map_err(|e| {
+            ILError::storage(format!(
+                "Failed to clone file handle {}: {e}",
+                self.relative_path
+            ))
+        })?;
+        let relative_path = self.relative_path.clone();
+        spawn_blocking(move || {
+            ranges
+                .into_iter()
+                .map(|range| read_range(&mut file, &relative_path, range))
+                .collect()
+        })
+        .await
+        .map_err(|e| ILError::storage(format!("Failed to join blocking read task: {e}")))?
     }
 }
 

--- a/storages/fs/src/storage.rs
+++ b/storages/fs/src/storage.rs
@@ -48,8 +48,9 @@ impl Storage for FsStorage {
 
     async fn open(&self, relative_path: &str) -> ILResult<Box<dyn InputFile>> {
         let path = self.absolute_path(relative_path);
-        let file = File::open(path)
-            .await
+        // Sync open: it is a cheap syscall, and each read dups the handle
+        // onto a blocking task (see file.rs).
+        let file = std::fs::File::open(path)
             .map_err(|e| ILError::storage(format!("Failed to open file {relative_path}: {e}")))?;
         let file = LocalInputFile {
             file,


### PR DESCRIPTION
## 动机

本地 FS 的 range 读是扫描热路径上的重要开销来源。一次扫描每个 parquet 数据文件需要多次小粒度随机读（footer、row group 列 chunk、row-id array），此前 `LocalInputFile` 基于 `tokio::fs::File` 实现——而 tokio 的 async File 是"假异步"：每个 `seek`/`read` 操作都会在内部打包成闭包派发到 blocking pool（微秒级调度开销），远高于 page cache 命中时 syscall 本身的纳秒级成本。1000 文件规模的一次全表扫描约产生 5000 次这样的 dispatch，调度开销主导了读耗时。

## 改动

- `LocalInputFile` 从 `tokio::fs::File` 切换为 `std::fs::File`：
  - `read_ranges`（覆盖 trait 的默认逐 range 实现）把整批 range 的 seek+read 放进**单个** `spawn_blocking` task 执行，整批只花一次 dispatch，runtime 完全退出热点路径；内部通过 `try_clone`（dup fd）把句柄交给 blocking task，fd cursor 共享的安全性由 trait 的 `&mut self` 串行化语义保证（已核对全部 `InputFile` 使用点确认无并发访问）。
  - `metadata()` 直接同步 fstat（廉价非阻塞 syscall，不值得 offload）。
- `storage.rs` 的 `open()` 改用同步 `std::fs::File::open`，并加注释说明理由。

写路径（`LocalOutputFile`）本次**未改动**。

## 性能对比

release 构建、`fs_bench` 两遍共 10 轮取中位数（与 main 对比，交换执行顺序复测结论一致）：

**1000 文件 / 100 万行：**

| phase | main | 本分支 | 提升 |
|---|---|---|---|
| scan_full | 183.3 ms | 123.5 ms | **1.48×** |
| scan_projection | 114.3 ms | 84.8 ms | **1.35×** |
| scan_filter | 213.0 ms | 153.5 ms | **1.39×** |
| scan_filter_range | 141.2 ms | 104.4 ms | **1.35×** |
| insert | ~1163 ms | ~1162 ms | 持平 |

**100 文件 / 10 万行**：四个扫描 phase 提升 1.07×–1.22×，insert 持平。文件数越多收益越大，与 dispatch 开销线性放大的模型吻合。

另做了对照实验：tokio File 上能做到的最好替代（每 range 独立 open + `try_join_all` 并发读）实测全面不敌本方案（每 range 3 次 dispatch、文件内并发度只有 2–3），tokio 路线已排除。

## 质量保障

- `cargo fmt` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通过；
- storage 集成测试通过（仅 docker 环境依赖项失败，与 main 相同、与本次改动无关）；
- bench 行数断言（全表/投影/等值 filter/range filter）全部通过；
- 已经过独立 code review：确认 `&mut self` 串行化对共享 fd cursor 充分、`read_ranges` 语义与 trait 默认实现一致（输出顺序/空输入/单 range 快速路径）、move/Send/panic 传播正确；采纳了 range 合法性守卫与注释措辞两处修正。