### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-benchmarks"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-catalog-postgres"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-catalog-sqlite"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-datafusion"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2792,14 +2792,14 @@ dependencies = [
 
 [[package]]
 name = "indexlake-datafusion-gen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost-build",
 ]
 
 [[package]]
 name = "indexlake-examples"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "indexlake",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-bm25"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-btree"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-hnsw"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-rabitq"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-index-rstar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-integration-tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "bytes",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-storage-fs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "indexlake-storage-s3"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 homepage = "https://github.com/systemxlabs/indexlake"
 license = "MIT"
@@ -27,18 +27,18 @@ repository = "https://github.com/systemxlabs/indexlake"
 rust-version = "1.89.0"
 
 [workspace.dependencies]
-indexlake = { path = "indexlake", version = "0.5.0" }
-indexlake-catalog-postgres = { path = "catalogs/postgres", version = "0.5.0" }
-indexlake-catalog-sqlite = { path = "catalogs/sqlite", version = "0.5.0" }
-indexlake-datafusion = { path = "integrations/datafusion", version = "0.5.0" }
-indexlake-index-bm25 = { path = "indexes/bm25", version = "0.5.0" }
-indexlake-index-btree = { path = "indexes/btree", version = "0.5.0" }
-indexlake-index-hnsw = { path = "indexes/hnsw", version = "0.5.0" }
-indexlake-index-rabitq = { path = "indexes/rabitq", version = "0.5.0" }
-indexlake-index-rstar = { path = "indexes/rstar", version = "0.5.0" }
-indexlake-integration-tests = { path = "integration-tests", version = "0.5.0" }
-indexlake-storage-fs = { path = "storages/fs", version = "0.5.0" }
-indexlake-storage-s3 = { path = "storages/s3", version = "0.5.0" }
+indexlake = { path = "indexlake", version = "0.6.0" }
+indexlake-catalog-postgres = { path = "catalogs/postgres", version = "0.6.0" }
+indexlake-catalog-sqlite = { path = "catalogs/sqlite", version = "0.6.0" }
+indexlake-datafusion = { path = "integrations/datafusion", version = "0.6.0" }
+indexlake-index-bm25 = { path = "indexes/bm25", version = "0.6.0" }
+indexlake-index-btree = { path = "indexes/btree", version = "0.6.0" }
+indexlake-index-hnsw = { path = "indexes/hnsw", version = "0.6.0" }
+indexlake-index-rabitq = { path = "indexes/rabitq", version = "0.6.0" }
+indexlake-index-rstar = { path = "indexes/rstar", version = "0.6.0" }
+indexlake-integration-tests = { path = "integration-tests", version = "0.6.0" }
+indexlake-storage-fs = { path = "storages/fs", version = "0.6.0" }
+indexlake-storage-s3 = { path = "storages/s3", version = "0.6.0" }
 
 arrow = "59"
 arrow-schema = "59"


### PR DESCRIPTION
Bump all workspace crate versions from 0.5.0 to 0.6.0.

- `workspace.package.version` -> 0.6.0
- All 12 `workspace.dependencies` path entries -> 0.6.0
- Regenerated Cargo.lock

All 15 workspace members now report 0.6.0.